### PR TITLE
Use Git for Versioning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
     name: Test on Emacs ${{ matrix.emacs_version }}
     steps:
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.9'
           architecture: 'x64'
       - name: Install Emacs
         uses: purcell/setup-emacs@master

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,17 @@ You can also explore adding new templates in ``mindstream-template-path`` (defau
 
 Try ``M-x mindstream- ...`` to see all the available interactive commands. These are also included as keybindings in a minor mode -- ``mindstream-mode`` -- which is enabled locally in scratch buffers.
 
+Design
+======
+
+Mindstream structures your workflow in sessions, which are version-controlled files. When you first start a session it begins as anonymous, meaning that it doesn't have a name. If the session develops into something worth keeping, you can save it to a preconfigured (or any) location on disk by giving the session a name. A session is stored as a version-controlled folder. You can also save just the file rather than the entire session. With that in mind, here are some properties of the design:
+
+1. There is only one anonymous scratch session active at any time.
+2. Saving an anonymous session turns it into a named session, and there is no active anonymous session at that point. Named sessions work the same as anonymous sessions aside from having a name and being in a permanent location on disk. A new anonymous session could be started at any time via `mindstream-new`.
+3. New sessions always begin as anonymous.
+4. Named sessions may be loaded without interfering with the active anonymous session.
+5. Any number of named sessions could be active at the same time. There is no global state, so that named sessions are self-contained and independent.
+
 Tips
 ====
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,9 @@ mindstream
 
 A rapid prototyping UX for Racket programming in Emacs, based on versioned and sessioned "scratch" buffers.
 
-In the future, this may be generalized for use with other languages and in authoring settings in general.
+Every mindstream session is represented as a unique Git repository on disk. The Git repo contains commits representing the stages in your development process, bounded either by ``racket-run`` invocations, or by calls to ``mindstream-clear`` which restores the buffer to a "clear" state, i.e. to its original template form. You can save and load these sessions, too.
+
+In the future, this package may be generalized for use with other languages and in authoring settings in general.
 
 Installation
 ============
@@ -16,6 +18,7 @@ This package isn't on `MELPA <https://melpa.org/>`_ yet, but you can install a p
 .. code-block:: elisp
 
   (use-package mindstream
+    :after racket-mode
     :straight
     (mindstream
       :type git
@@ -27,16 +30,31 @@ This package isn't on `MELPA <https://melpa.org/>`_ yet, but you can install a p
 Usage
 =====
 
-If you'd like to try out this early version (you pioneer, you!), here's how you can do it:
+If you'd like to try it out, follow these steps:
 
 1. Follow the installation instructions above to install this package using straight.el
 2. Ensure ``(mindstream-initialize)`` is somewhere in your config. This advises Racket Mode's ``racket-run`` to "iterate" the scratch buffer, providing implicit versioning for your Racket scratch buffer.
 3. Run ``mindstream-new`` to create a Racket scratch buffer.
 4. Hack away!
 
-You can also explore adding new templates in ``mindstream-template-path`` (default: ``"~/.mindstream/templates/"``) -- ordinary Racket files -- which will then be available as options in ``mindstream-new``. You can also save scratch buffers that you'd like to keep, or even entire scratch buffer sessions (which are simply saved as a directory containing a series of Racket files representing stages in your development process, bounded either by ``racket-run`` invocations, or by calls to ``mindstream-clear`` which restores the buffer to a "clear" state, i.e. to its original template form).
+You can also explore adding new templates in ``mindstream-template-path`` (default: ``"~/.mindstream/templates/"``) -- ordinary Racket files -- which will then be available as options in ``mindstream-new``. You can also save scratch buffers that you'd like to keep, or even entire scratch buffer sessions (which clones the mindstream Git repo to a location you specify).
 
-Try ``M-x mindstream- ...`` to see all the available interactive commands. These are also included as keybindings in a global minor mode -- try ``mindstream-mode``.
+Try ``M-x mindstream- ...`` to see all the available interactive commands. These are also included as keybindings in a minor mode -- ``mindstream-mode`` -- which is enabled locally in scratch buffers.
+
+Tips
+====
+
+Magit
+-----
+
+Mindstream sessions are stored as Git repos, so you can use standard Git tools as you might with any repo, including Magit.
+
+Magit is useful to navigate the states in the session and see diffs representing the changes in each state. Of course, Magit can be used for a great many things, and you have that full power available to you to use with Mindstream sessions.
+
+Git-Timemachine
+---------------
+
+The git-timemachine Emacs package is a great way to temporally navigate your session. Unlike the usual undo and redo operations which track edits with high granularity, mindstream sessions are bounded by ``racket-run`` invocations which tend to represent natural, distinct stages in your development. Mindstream doesn't include a built-in way to navigate these states, but you can use the git-timemachine package to do this (in read-only mode).
 
 Acknowledgements
 ================

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -72,7 +72,7 @@
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-buffer-name "*scratch - Racket*"
+(defcustom mindstream-anonymous-buffer-name "*scratch - Racket*"
   "The name of the mindstream scratch buffer."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -32,11 +32,6 @@
   "A scratch buffer."
   :group 'Editing)
 
-(defcustom mindstream-path "/var/tmp/racket/"
-  "Directory path where mindstream buffers will be saved during development."
-  :type 'string
-  :group 'mindstream)
-
 (defcustom mindstream-path "/var/tmp/racket/" ; TODO: make platform-independent?
   "Directory path where mindstream buffers will be saved during development."
   :type 'string

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -67,6 +67,11 @@
   :type 'string
   :group 'mindstream)
 
+(defcustom mindstream-filename "scratch"
+  "Filename to use for mindstream buffers."
+  :type 'string
+  :group 'mindstream)
+
 (defcustom mindstream-buffer-name "*scratch - Racket*"
   "The name of the mindstream scratch buffer."
   :type 'string

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -98,12 +98,6 @@ New sessions always start anonymous."
     (insert-file-contents filename)
     (buffer-string)))
 
-(defun mindstream--buffer-index (buffer)
-  "Get the index of the buffer in the current scratch session."
-  (string-to-number
-   (file-name-base
-    (buffer-file-name buffer))))
-
 (defun mindstream--initialize-buffer ()
   "Initialize a newly created buffer.
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -3,7 +3,6 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/mindstream
 ;; Version: 0.0
-;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at
@@ -34,23 +33,30 @@
 (require 'mindstream-util)
 
 (defvar-local mindstream-session-name nil
-  "The name of the mindstream session represented by the current buffer. For anonymous sessions this is a randomly generated identifier, while for named sessions it's the name of the containing folder.")
+  "The name of the mindstream session represented by the current buffer.
+
+For anonymous sessions this is a randomly generated identifier, while
+for named sessions it's the name of the containing folder.")
 
 (defvar-local mindstream-template-used nil
-  "The template used (if any) in creating the current buffer. This is a string representing a path to a file on disk.")
+  "The template used (if any) in creating the current buffer.
+
+This is a string representing a path to a file on disk.")
 
 (defun mindstream--unique-session-name ()
   "Unique name for a scratch buffer session."
   (let ((time (current-time)))
-    (concat (format-time-string "%Y-%m-%d" time)
+    (concat (format-time-string "%F" time)
             "-"
             (sha1 (format "%s" time)))))
 
 (cl-defun mindstream-start-session (&optional template)
   "Start a new anonymous session.
 
-This updates the current session name and creates a new directory
-and Git repository for the new session.
+This creates a new directory and Git repository for the new
+session. It populates the empty buffer with the contents of TEMPLATE
+if one is specified. Otherwise, it uses the configured default
+template.
 
 New sessions always start anonymous."
   (let* ((session (mindstream--unique-session-name))
@@ -104,8 +110,7 @@ New sessions always start anonymous."
 This sets the major mode and any other necessary attributes."
   ;; TODO: instead of hardcoding the major mode, just let Emacs
   ;; choose it based on the file extension
-  (let* ((buffer-name mindstream-buffer-name)
-         (major-mode-to-use mindstream-major-mode))
+  (let ((major-mode-to-use mindstream-major-mode))
     (unless (eq major-mode major-mode-to-use)
       (funcall major-mode-to-use))
     (setq buffer-offer-save nil)

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -63,6 +63,7 @@ New sessions always start anonymous."
       (mindstream--execute-shell-command "git init" base-path)
       (with-current-buffer buf
         (setq mindstream-session-name session)
+        (mindstream-mode 1)
         (write-file filename))
       buf)))
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'mindstream-custom)
+(require 'mindstream-util)
 
 (defvar-local mindstream-session-name nil
   "The name of the mindstream session represented by the current buffer. For anonymous sessions this is a randomly generated identifier, while for named sessions it's the name of the containing folder.")
@@ -63,7 +64,6 @@ New sessions always start anonymous."
       (mindstream--execute-shell-command "git init" base-path)
       (with-current-buffer buf
         (setq mindstream-session-name session)
-        (mindstream-mode 1)
         (write-file filename))
       buf)))
 
@@ -145,24 +145,6 @@ if Emacs is exited."
   "Get the active scratch buffer, if it exists."
   (let ((buffer-name mindstream-buffer-name))
     (get-buffer buffer-name)))
-
-(defun mindstream--get-or-create-scratch-buffer ()
-  "Get the active scratch buffer or create a new one.
-
-If the scratch buffer doesn't exist, this creates a new one using
-the default configured template.
-
-This is a convenience utility for \"read only\" cases where we simply want to
-get the scratch buffer - whatever it may be. It is too connoted to be
-useful in features implementing the scratch buffer iteration model."
-  (or (mindstream--get-anonymous-scratch-buffer)
-      (mindstream-new mindstream-default-template)))
-
-(defun mindstream-switch-to-scratch-buffer ()
-  "Switch to the anonymous scratch buffer."
-  (interactive)
-  (let ((buf (mindstream--get-or-create-scratch-buffer)))
-    (switch-to-buffer buf)))
 
 (defun mindstream-anonymous-scratch-buffer-p ()
   "Predicate to check if the current buffer is the anonymous scratch buffer."

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -40,7 +40,6 @@
             "-"
             (sha1 (format "%s" time)))))
 
-;; TODO: rename to start-anonymous-session
 (cl-defun mindstream-start-session (&optional template)
   "Start a new anonymous session.
 
@@ -91,7 +90,7 @@ New sessions always start anonymous."
 (defun mindstream--initialize-buffer ()
   "Initialize a newly created buffer.
 
-This sets the session name and any other necessary attributes."
+This sets the major mode and any other necessary attributes."
   ;; TODO: instead of hardcoding the major mode, just let Emacs
   ;; choose it based on the file extension
   (let* ((buffer-name mindstream-buffer-name)
@@ -99,7 +98,6 @@ This sets the session name and any other necessary attributes."
     (unless (eq major-mode major-mode-to-use)
       (funcall major-mode-to-use))
     (setq buffer-offer-save nil)
-    (setq-local buffer-session mindstream-session-name)
     ;; Ignore whatever `racket-repl-buffer-name-function' just did to
     ;; set `racket-repl-buffer-name' and give this its own REPL.
     (setq-local racket-repl-buffer-name "*scratch - Racket REPL*")
@@ -115,8 +113,7 @@ As a \"scratch\" buffer, its contents will be treated as
 disposable, and it will not prompt to save if it is closed or
 if Emacs is exited."
   (let* ((buffer-name mindstream-buffer-name)
-         (buf (generate-new-buffer buffer-name))
-         (major-mode-to-use mindstream-major-mode))
+         (buf (generate-new-buffer buffer-name)))
     (with-current-buffer buf
       (insert contents)
       (mindstream--initialize-buffer))

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -29,6 +29,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'mindstream-custom)
 (require 'mindstream-util)
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -47,17 +47,23 @@ This updates the current session name and creates a new directory
 and Git repository for the new session."
   (setq mindstream-session-name (mindstream--unique-session-name))
   (let* ((session mindstream-session-name)
-         (base-path (mindstream--session-path session)))
+         (base-path (mindstream--generate-session-path session)))
     (unless (file-directory-p base-path)
       (mkdir base-path t)
       (mindstream--execute-shell-command "git init" base-path))))
 
-(cl-defun mindstream--session-path (&optional session)
-  "Path to the directory on disk containing SESSION."
+(cl-defun mindstream--generate-session-path (&optional session)
+  "A path on disk to use for a newly created SESSION."
   (let ((session (or session mindstream-session-name)))
     (concat (file-name-as-directory mindstream-path)
             (file-name-as-directory session))))
 
+(cl-defun mindstream--current-session-path ()
+  "Path to the directory on disk containing the current session."
+  (let ((buf (mindstream--get-scratch-buffer)))
+    (and buf
+         (file-name-directory
+          (buffer-file-name buf)))))
 
 (defun mindstream--ensure-templates-exist ()
   "Ensure that the templates directory exists and contains the default template."

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -132,6 +132,9 @@ if Emacs is exited."
     (with-current-buffer buf
       ;; store the template used as a buffer-local variable
       ;; on the scratch buffer
+      ;; TODO: rename to mindstream-template-used
+      ;; and also declare/document it so we know it's a fully
+      ;; qualified path
       (setq-local buffer-template template))
     buf))
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -40,6 +40,7 @@
             "-"
             (sha1 (format "%s" time)))))
 
+;; TODO: rename to start-anonymous-session
 (defun mindstream-start-session ()
   "Start a new session.
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -31,7 +31,11 @@
 
 (require 'mindstream-custom)
 
-(defvar-local mindstream-session-name nil)
+(defvar-local mindstream-session-name nil
+  "The name of the mindstream session represented by the current buffer. For anonymous sessions this is a randomly generated identifier, while for named sessions it's the name of the containing folder.")
+
+(defvar-local mindstream-template-used nil
+  "The template used (if any) in creating the current buffer. This is a string representing a path to a file on disk.")
 
 (defun mindstream--unique-session-name ()
   "Unique name for a scratch buffer session."
@@ -127,10 +131,9 @@ if Emacs is exited."
     (with-current-buffer buf
       ;; store the template used as a buffer-local variable
       ;; on the scratch buffer
-      ;; TODO: rename to mindstream-template-used
       ;; and also declare/document it so we know it's a fully
       ;; qualified path
-      (setq-local buffer-template template))
+      (setq mindstream-template-used template))
     buf))
 
 (defun mindstream--get-anonymous-scratch-buffer ()

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -53,10 +53,9 @@ This is a string representing a path to a file on disk.")
 (cl-defun mindstream-start-session (&optional template)
   "Start a new anonymous session.
 
-This creates a new directory and Git repository for the new
-session. It populates the empty buffer with the contents of TEMPLATE
-if one is specified. Otherwise, it uses the configured default
-template.
+This creates a new directory and Git repository for the new session.
+It populates the empty buffer with the contents of TEMPLATE if one is
+specified.  Otherwise, it uses the configured default template.
 
 New sessions always start anonymous."
   (let* ((session (mindstream--unique-session-name))

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -65,7 +65,8 @@ New sessions always start anonymous."
       (mindstream--execute-shell-command "git init" base-path)
       (with-current-buffer buf
         (setq mindstream-session-name session)
-        (write-file filename))
+        (write-file filename)
+        (rename-buffer mindstream-buffer-name))
       buf)))
 
 (defun mindstream--generate-anonymous-session-path (session)

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -54,15 +54,19 @@ New sessions always start anonymous."
   (let* ((session (mindstream--unique-session-name))
          (base-path (mindstream--generate-anonymous-session-path session))
          (template (or template mindstream-default-template))
-         (buf (mindstream--new-buffer-from-template template)))
+         (buf (mindstream--new-buffer-from-template template))
+         (filename (concat base-path
+                           mindstream-filename
+                           mindstream-file-extension)))
     (unless (file-directory-p base-path)
       (mkdir base-path t)
       (mindstream--execute-shell-command "git init" base-path)
       (with-current-buffer buf
-        (setq mindstream-session-name session))
+        (setq mindstream-session-name session)
+        (write-file filename))
       buf)))
 
-(cl-defun mindstream--generate-anonymous-session-path (session)
+(defun mindstream--generate-anonymous-session-path (session)
   "A path on disk to use for a newly created SESSION."
   (concat (file-name-as-directory mindstream-path)
           (file-name-as-directory session)))

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -1,0 +1,171 @@
+;;; mindstream-scratch.el --- A scratch buffer -*- lexical-binding: t -*-
+
+;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
+;; URL: https://github.com/countvajhula/mindstream
+;; Version: 0.0
+;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452"))
+;; Keywords: lisp, convenience, languages
+
+;; This program is "part of the world," in the sense described at
+;; https://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+
+;; A scratch buffer.
+
+;;; Code:
+
+(require 'mindstream-custom)
+
+(setq mindstream-session-name nil) ; TODO: rename to reflect "scratch" session
+
+(defun mindstream--unique-session-name ()
+  "Unique name for a scratch buffer session."
+  (let ((time (current-time)))
+    (concat (format-time-string "%Y-%m-%d" time)
+            "-"
+            (sha1 (format "%s" time)))))
+
+(defun mindstream-start-session ()
+  "Start a new session.
+
+This updates the current session name and creates a new directory
+and Git repository for the new session."
+  (setq mindstream-session-name (mindstream--unique-session-name))
+  (let* ((session mindstream-session-name)
+         (base-path (mindstream--session-path session)))
+    (unless (file-directory-p base-path)
+      (mkdir base-path t)
+      (mindstream--execute-shell-command "git init" base-path))))
+
+(cl-defun mindstream--session-path (&optional session)
+  "Path to the directory on disk containing SESSION."
+  (let ((session (or session mindstream-session-name)))
+    (concat (file-name-as-directory mindstream-path)
+            (file-name-as-directory session))))
+
+(cl-defun mindstream--session-max-index (&optional session)
+  "Max (latest) index for the current session."
+  (let* ((session (or session mindstream-session-name))
+         (path (mindstream--session-path session))
+         ;; note that non-numeric filenames are converted to
+         ;; index 0 by string-to-number. That shouldn't be
+         ;; relevant for our purposes since we're picking
+         ;; the largest, in any case.
+         (indices (seq-map
+                   ;; filter to only numbers and then sort them
+                   ;; as numbers
+                   (lambda (filespec) (string-to-number (car filespec)))
+                   (directory-files-and-attributes path))))
+    (apply #'max indices)))
+
+(defun mindstream--ensure-templates-exist ()
+  "Ensure that the templates directory exists and contains the default template."
+  ;; consider alternative: an initialization function to do this the first time
+  (unless (file-directory-p mindstream-template-path)
+    (mkdir mindstream-template-path t)
+    (let ((buf (generate-new-buffer "default-template")))
+      (with-current-buffer buf
+        (insert "#lang racket\n\n")
+        (write-file (concat mindstream-template-path
+                            mindstream-default-template-name)))
+      (kill-buffer buf))))
+
+(defun mindstream--file-contents (filename)
+  "Get contents of FILENAME as a string."
+  (with-temp-buffer
+    (insert-file-contents filename)
+    (buffer-string)))
+
+(defun mindstream--buffer-index (buffer)
+  "Get the index of the buffer in the current scratch session."
+  (string-to-number
+   (file-name-base
+    (buffer-file-name buffer))))
+
+(defun mindstream--initialize-buffer ()
+  "Initialize a newly created buffer.
+
+This sets the session name and any other necessary attributes."
+  (let* ((buffer-name mindstream-buffer-name)
+         (major-mode-to-use mindstream-major-mode))
+    (unless (eq major-mode major-mode-to-use)
+      (funcall major-mode-to-use))
+    (setq buffer-offer-save nil)
+    (setq-local buffer-session mindstream-session-name)
+    ;; Ignore whatever `racket-repl-buffer-name-function' just did to
+    ;; set `racket-repl-buffer-name' and give this its own REPL.
+    (setq-local racket-repl-buffer-name "*scratch - Racket REPL*")
+    ;; place point at the end of the buffer
+    (goto-char (point-max))))
+
+(defun mindstream--new-buffer-with-contents (contents)
+  "Create a new scratch buffer containing CONTENTS.
+
+This does not save the buffer.
+
+As a \"scratch\" buffer, its contents will be treated as
+disposable, and it will not prompt to save if it is closed or
+if Emacs is exited."
+  (let* ((buffer-name mindstream-buffer-name)
+         (buf (generate-new-buffer buffer-name))
+         (major-mode-to-use mindstream-major-mode))
+    (with-current-buffer buf
+      (insert contents)
+      (mindstream--initialize-buffer))
+    buf))
+
+(defun mindstream--new-buffer-from-template (template)
+  "Create a new (unsaved) buffer from TEMPLATE."
+  (mindstream--ensure-templates-exist)
+  (let* ((contents (mindstream--file-contents template))
+         (buf (mindstream--new-buffer-with-contents contents)))
+    (with-current-buffer buf
+      ;; store the template used as a buffer-local variable
+      ;; on the scratch buffer
+      (setq-local buffer-template template))
+    buf))
+
+(defun mindstream--get-scratch-buffer ()
+  "Get the active scratch buffer, if it exists."
+  (let ((buffer-name mindstream-buffer-name))
+    (get-buffer buffer-name)))
+
+(defun mindstream--get-or-create-scratch-buffer ()
+  "Get the active scratch buffer or create a new one.
+
+If the scratch buffer doesn't exist, this creates a new one using
+the default configured template.
+
+This is a convenience utility for \"read only\" cases where we simply want to
+get the scratch buffer - whatever it may be. It is too connoted to be
+useful in features implementing the scratch buffer iteration model."
+  (or (mindstream--get-scratch-buffer)
+      (mindstream-new mindstream-default-template)))
+
+(defun mindstream-switch-to-scratch-buffer ()
+  "Switch to scratch buffer."
+  (interactive)
+  (let ((buf (mindstream--get-or-create-scratch-buffer)))
+    (switch-to-buffer buf)))
+
+(defun mindstream-scratch-buffer-p ()
+  "Predicate to check if the current buffer is the Scratch buffer."
+  (equal mindstream-buffer-name (buffer-name)))
+
+(provide 'mindstream-scratch)
+;;; mindstream-scratch.el ends here

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -31,7 +31,7 @@
 
 (require 'mindstream-custom)
 
-(setq mindstream-session-name nil) ; TODO: rename to reflect "scratch" session
+(defvar mindstream-session-name nil) ; TODO: rename to reflect "scratch" session
 
 (defun mindstream--unique-session-name ()
   "Unique name for a scratch buffer session."

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -71,7 +71,7 @@ New sessions always start anonymous."
       (with-current-buffer buf
         (setq mindstream-session-name session)
         (write-file filename)
-        (rename-buffer mindstream-buffer-name))
+        (rename-buffer mindstream-anonymous-buffer-name))
       buf)))
 
 (defun mindstream--generate-anonymous-session-path (session)
@@ -121,7 +121,7 @@ This does not save the buffer.
 As a \"scratch\" buffer, its contents will be treated as
 disposable, and it will not prompt to save if it is closed or
 if Emacs is exited."
-  (let* ((buffer-name mindstream-buffer-name)
+  (let* ((buffer-name mindstream-anonymous-buffer-name)
          (buf (generate-new-buffer buffer-name)))
     (with-current-buffer buf
       (insert contents)
@@ -143,12 +143,12 @@ if Emacs is exited."
 
 (defun mindstream--get-anonymous-scratch-buffer ()
   "Get the active scratch buffer, if it exists."
-  (let ((buffer-name mindstream-buffer-name))
+  (let ((buffer-name mindstream-anonymous-buffer-name))
     (get-buffer buffer-name)))
 
 (defun mindstream-anonymous-scratch-buffer-p ()
   "Predicate to check if the current buffer is the anonymous scratch buffer."
-  (equal mindstream-buffer-name (buffer-name)))
+  (equal mindstream-anonymous-buffer-name (buffer-name)))
 
 (provide 'mindstream-scratch)
 ;;; mindstream-scratch.el ends here

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -101,6 +101,8 @@ and Git repository for the new session."
   "Initialize a newly created buffer.
 
 This sets the session name and any other necessary attributes."
+  ;; TODO: instead of hardcoding the major mode, just let Emacs
+  ;; choose it based on the file extension
   (let* ((buffer-name mindstream-buffer-name)
          (major-mode-to-use mindstream-major-mode))
     (unless (eq major-mode major-mode-to-use)

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -42,10 +42,12 @@
 
 ;; TODO: rename to start-anonymous-session
 (defun mindstream-start-session ()
-  "Start a new session.
+  "Start a new anonymous session.
 
 This updates the current session name and creates a new directory
-and Git repository for the new session."
+and Git repository for the new session.
+
+New sessions always start anonymous."
   (setq mindstream-session-name (mindstream--unique-session-name))
   (let* ((session mindstream-session-name)
          (base-path (mindstream--generate-session-path session)))
@@ -58,13 +60,6 @@ and Git repository for the new session."
   (let ((session (or session mindstream-session-name)))
     (concat (file-name-as-directory mindstream-path)
             (file-name-as-directory session))))
-
-(cl-defun mindstream--current-session-path ()
-  "Path to the directory on disk containing the current session."
-  (let ((buf (mindstream--get-scratch-buffer)))
-    (and buf
-         (file-name-directory
-          (buffer-file-name buf)))))
 
 (defun mindstream--ensure-templates-exist ()
   "Ensure that the templates directory exists and contains the default template."
@@ -138,7 +133,7 @@ if Emacs is exited."
       (setq-local buffer-template template))
     buf))
 
-(defun mindstream--get-scratch-buffer ()
+(defun mindstream--get-anonymous-scratch-buffer ()
   "Get the active scratch buffer, if it exists."
   (let ((buffer-name mindstream-buffer-name))
     (get-buffer buffer-name)))
@@ -152,17 +147,17 @@ the default configured template.
 This is a convenience utility for \"read only\" cases where we simply want to
 get the scratch buffer - whatever it may be. It is too connoted to be
 useful in features implementing the scratch buffer iteration model."
-  (or (mindstream--get-scratch-buffer)
+  (or (mindstream--get-anonymous-scratch-buffer)
       (mindstream-new mindstream-default-template)))
 
 (defun mindstream-switch-to-scratch-buffer ()
-  "Switch to scratch buffer."
+  "Switch to the anonymous scratch buffer."
   (interactive)
   (let ((buf (mindstream--get-or-create-scratch-buffer)))
     (switch-to-buffer buf)))
 
-(defun mindstream-scratch-buffer-p ()
-  "Predicate to check if the current buffer is the Scratch buffer."
+(defun mindstream-anonymous-scratch-buffer-p ()
+  "Predicate to check if the current buffer is the anonymous scratch buffer."
   (equal mindstream-buffer-name (buffer-name)))
 
 (provide 'mindstream-scratch)

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -58,20 +58,6 @@ and Git repository for the new session."
     (concat (file-name-as-directory mindstream-path)
             (file-name-as-directory session))))
 
-(cl-defun mindstream--session-max-index (&optional session)
-  "Max (latest) index for the current session."
-  (let* ((session (or session mindstream-session-name))
-         (path (mindstream--session-path session))
-         ;; note that non-numeric filenames are converted to
-         ;; index 0 by string-to-number. That shouldn't be
-         ;; relevant for our purposes since we're picking
-         ;; the largest, in any case.
-         (indices (seq-map
-                   ;; filter to only numbers and then sort them
-                   ;; as numbers
-                   (lambda (filespec) (string-to-number (car filespec)))
-                   (directory-files-and-attributes path))))
-    (apply #'max indices)))
 
 (defun mindstream--ensure-templates-exist ()
   "Ensure that the templates directory exists and contains the default template."

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -32,6 +32,11 @@
 (require 'mindstream-custom)
 (require 'mindstream-util)
 
+;; These are customization or config variables defined elsewhere;
+;; explicitly declare them here to avoid byte compile warnings
+;; TODO: handle this via an explicit configuration step
+(defvar racket-repl-buffer-name)
+
 (defvar-local mindstream-session-name nil
   "The name of the mindstream session represented by the current buffer.
 

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -1,0 +1,40 @@
+;;; mindstream-util.el --- A scratch buffer -*- lexical-binding: t -*-
+
+;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
+;; URL: https://github.com/countvajhula/mindstream
+;; Version: 0.0
+;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452"))
+;; Keywords: lisp, convenience, languages
+
+;; This program is "part of the world," in the sense described at
+;; https://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+
+;; A scratch buffer.
+
+;;; Code:
+
+(cl-defun mindstream--execute-shell-command (command &optional directory)
+  "Execute COMMAND at DIRECTORY and return its output."
+  (let ((default-directory (or directory
+                               (file-name-directory (buffer-file-name)))))
+    (shell-command-to-string command)))
+
+
+(provide 'mindstream-util)
+;;; mindstream-util.el ends here

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -29,6 +29,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (cl-defun mindstream--execute-shell-command (command &optional directory)
   "Execute COMMAND at DIRECTORY and return its output."
   (let ((default-directory (or directory

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -3,7 +3,6 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/mindstream
 ;; Version: 0.0
-;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at

--- a/mindstream.el
+++ b/mindstream.el
@@ -29,6 +29,8 @@
 
 ;;; Code:
 
+(require 'magit-git)
+
 (require 'mindstream-custom)
 (require 'mindstream-scratch)
 (require 'mindstream-util)
@@ -217,9 +219,9 @@ backwards in the scratch buffer history."
 
 This only iterates the buffer if it is the current buffer and has been
 modified since the last persistent state. Otherwise, it takes no action."
-  (when (and mindstream-mode (buffer-modified-p))
-    ;; TODO: this doesn't iterate if we save the buffer via C-x C-s
-    ;; so it should also check for modification on disk
+  (when (and mindstream-mode
+             (or (buffer-modified-p)
+                 (magit-anything-modified-p)))
     (mindstream--iterate))
   (let ((result (apply orig-fn args)))
     result))

--- a/mindstream.el
+++ b/mindstream.el
@@ -218,6 +218,8 @@ backwards in the scratch buffer history."
 This only iterates the buffer if it is the current buffer and has been
 modified since the last persistent state. Otherwise, it takes no action."
   (when (and mindstream-mode (buffer-modified-p))
+    ;; TODO: this doesn't iterate if we save the buffer via C-x C-s
+    ;; so it should also check for modification on disk
     (mindstream--iterate))
   (let ((result (apply orig-fn args)))
     result))

--- a/mindstream.el
+++ b/mindstream.el
@@ -54,12 +54,12 @@
 ;; 3. Named sessions may be loaded without interfering with the active
 ;;    anonymous session.
 ;; 4. Any number of named sessions could be active at the same time.
-;;    State should be maintained on the filesystem or in buffer-locals
-;;    (i.e. no global state) to keep named sessions self-contained and independent.
 ;; 5. Saving an anonymous session turns it into a named session, and there
 ;;    is no active anonymous session at that point. A new one could be
 ;;    started via `new`.
 ;; -> document the UX in some form of user's manual at some point.
+;; TODO: test that loading a saved session works the same as anonymous
+;;       sessions.
 ;; TODO: saving a scratch buffer should switch focus to the newly
 ;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart

--- a/mindstream.el
+++ b/mindstream.el
@@ -46,6 +46,7 @@
     (define-key mindstream-map (kbd "C-c C-r c") #'mindstream-clear)
     (define-key mindstream-map (kbd "C-c C-r s") #'mindstream-save-file)
     (define-key mindstream-map (kbd "C-c C-r S") #'mindstream-save-session)
+    (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
     mindstream-map)
   (if mindstream-mode
       (mindstream-initialize)

--- a/mindstream.el
+++ b/mindstream.el
@@ -268,6 +268,7 @@ you would typically want to specify a new, non-existent folder."
                             mindstream-file-extension)
                     dir)))
     (find-file filename)
+    (mindstream-mode 1)
     (setq mindstream-session-name session)))
 
 (defun mindstream--get-or-create-scratch-buffer ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -48,16 +48,9 @@
     (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
     mindstream-map))
 
-;; TODO: saving a scratch buffer should switch focus to the newly
-;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart
 ;;       from the scratch buffer?
 ;; TODO: restore navigation backwards and forwards
-;; TODO: test "save file" still works
-;; TODO: restore "save session" functionality (probably just
-;;       git-clone it to another path without setting an upstream)
-;; TODO: test that git-timemachine for read-only navigation
-;;       and magit for all the usual stuff work out of the box
 ;; TODO: use first line of changeset as commit message?
 ;; TODO: start with linearized navigation of versions,
 ;;       i.e. modification of any prior state results

--- a/mindstream.el
+++ b/mindstream.el
@@ -244,5 +244,28 @@ directly."
   (copy-directory (mindstream--session-path mindstream-session-name)
                   dir))
 
+(defun mindstream-load-session (dir)
+  "Load a session from a directory."
+  (interactive (list (read-directory-name "Load session: " mindstream-save-session-path)))
+  ;; save and delete existing scratch buffer
+  ;; open scratch file
+  ;; rename it to scratch
+  (with-current-buffer (mindstream--get-scratch-buffer)
+    ;; first write the existing scratch buffer
+    ;; if there are unsaved changes
+    (mindstream-write)
+    ;; then kill it
+    (kill-buffer))
+  (let* ((session (file-name-nondirectory
+                   (string-trim default-directory "" "/")))
+         (filename (concat dir
+                           mindstream-filename
+                           mindstream-file-extension)))
+    (find-file filename)
+    ;; TODO: this should be in a setup function somewhere
+    ;; so it doesn't need to be duplicated
+    (setq mindstream-session-name session)
+    (rename-buffer mindstream-buffer-name)))
+
 (provide 'mindstream)
 ;;; mindstream.el ends here

--- a/mindstream.el
+++ b/mindstream.el
@@ -45,10 +45,7 @@
     (define-key mindstream-map (kbd "C-c C-r s") #'mindstream-save-file)
     (define-key mindstream-map (kbd "C-c C-r S") #'mindstream-save-session)
     (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
-    mindstream-map)
-  (if mindstream-mode
-      (mindstream-initialize)
-    (mindstream-disable)))
+    mindstream-map))
 
 ;; TODO:
 ;; 1. There can only be one anonymous scratch session active at any time.

--- a/mindstream.el
+++ b/mindstream.el
@@ -108,7 +108,7 @@ it should typically be run using `with-current-buffer`."
     ;; writing the file changes the buffer name to the filename,
     ;; so we restore the original buffer name
     (when anonymous
-      (rename-buffer mindstream-buffer-name))
+      (rename-buffer mindstream-anonymous-buffer-name))
     (mindstream--commit)))
 
 (defun mindstream--end-session ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -257,7 +257,7 @@ directly."
   (mindstream--end-session)
   ;; restore the old session
   (let* ((session (file-name-nondirectory
-                   (string-trim default-directory "" "/")))
+                   (string-trim dir "" "/")))
          (filename (concat dir
                            mindstream-filename
                            mindstream-file-extension)))

--- a/mindstream.el
+++ b/mindstream.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/mindstream
 ;; Version: 0.0
-;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452"))
+;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452") (magit "3.3.0"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at

--- a/mindstream.el
+++ b/mindstream.el
@@ -51,6 +51,8 @@
       (mindstream-initialize)
     (mindstream-disable)))
 
+;; TODO: should there be a distinct notion of "session" apart
+;;       from the scratch buffer?
 ;; TODO: restore navigation backwards and forwards
 ;; TODO: test "save file" still works
 ;; TODO: restore "save session" functionality (probably just

--- a/mindstream.el
+++ b/mindstream.el
@@ -125,11 +125,10 @@ a named session that you may happen to be visiting."
         ;; then kill it
         (kill-buffer)))))
 
-(defun mindstream-new (template)
+(defun mindstream--new (template)
   "Start a new scratch buffer using a specific TEMPLATE.
 
 This also begins a new session."
-  (interactive (list (read-file-name "Which template? " mindstream-template-path)))
   ;; end the current anonymous session
   (mindstream--end-session)
   ;; start a new session (sessions always start anonymous)
@@ -138,6 +137,14 @@ This also begins a new session."
     (with-current-buffer buf
       (mindstream-mode 1)
       (mindstream--iterate))
+    buf))
+
+(defun mindstream-new (template)
+  "Start a new scratch buffer using a specific TEMPLATE.
+
+This also begins a new session."
+  (interactive (list (read-file-name "Which template? " mindstream-template-path)))
+  (let ((buf (mindstream--new template)))
     (switch-to-buffer buf)))
 
 (defun mindstream-clear ()
@@ -245,7 +252,7 @@ want to get the scratch buffer - whatever it may be. It is too
 connoted to be useful in features implementing the scratch buffer
 iteration model."
   (or (mindstream--get-anonymous-scratch-buffer)
-      (mindstream-new mindstream-default-template)))
+      (mindstream--new mindstream-default-template)))
 
 (defun mindstream-switch-to-scratch-buffer ()
   "Switch to the anonymous scratch buffer."

--- a/mindstream.el
+++ b/mindstream.el
@@ -51,6 +51,8 @@
       (mindstream-initialize)
     (mindstream-disable)))
 
+;; TODO: saving a scratch buffer should switch focus to the newly
+;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart
 ;;       from the scratch buffer?
 ;; TODO: restore navigation backwards and forwards

--- a/mindstream.el
+++ b/mindstream.el
@@ -35,6 +35,11 @@
 (require 'mindstream-scratch)
 (require 'mindstream-util)
 
+;; These are customization or config variables defined elsewhere;
+;; explicitly declare them here to avoid byte compile warnings
+;; TODO: handle this via an explicit configuration step
+(declare-function racket-run "ext:racket-mode")
+
 ;;;###autoload
 (define-minor-mode mindstream-mode
   "Minor mode providing keybindings for mindstream mode."

--- a/mindstream.el
+++ b/mindstream.el
@@ -48,18 +48,9 @@
     (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
     mindstream-map))
 
-;; TODO:
-;; 1. There can only be one anonymous scratch session active at any time.
-;; 2. New sessions always begin as anonymous.
-;; 3. Named sessions may be loaded without interfering with the active
-;;    anonymous session.
-;; 4. Any number of named sessions could be active at the same time.
-;; 5. Saving an anonymous session turns it into a named session, and there
-;;    is no active anonymous session at that point. A new one could be
-;;    started via `new`.
-;; -> document the UX in some form of user's manual at some point.
-;; TODO: test that loading a saved session works the same as anonymous
-;;       sessions.
+;; TODO: test that saving as a file does not preserve the anonymous
+;;       session, but also disables mindstream mode on the saved
+;;       file [mindstream mode is still enabled]
 ;; TODO: saving a scratch buffer should switch focus to the newly
 ;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart

--- a/mindstream.el
+++ b/mindstream.el
@@ -48,9 +48,6 @@
     (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
     mindstream-map))
 
-;; TODO: test that saving as a file does not preserve the anonymous
-;;       session, but also disables mindstream mode on the saved
-;;       file [mindstream mode is still enabled]
 ;; TODO: saving a scratch buffer should switch focus to the newly
 ;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart
@@ -190,7 +187,8 @@ existing (tmp) location, use a low-level utility like `save-buffer` or
   (interactive (list (read-file-name "Save file as: " mindstream-save-file-path "")))
   (unless mindstream-mode
     (error "Not a mindstream buffer!"))
-  (write-file filename))
+  (write-file filename)
+  (mindstream-mode -1))
 
 (defun mindstream-save-session (dest-dir)
   "Save the current scratch session to a directory.

--- a/mindstream.el
+++ b/mindstream.el
@@ -60,6 +60,10 @@
 ;; 4. Any number of named sessions could be active at the same time.
 ;;    State should be maintained on the filesystem or in buffer-locals
 ;;    (i.e. no global state) to keep named sessions self-contained and independent.
+;; 5. Saving an anonymous session turns it into a named session, and there
+;;    is no active anonymous session at that point. A new one could be
+;;    started via `new`.
+;; -> document the UX in some form of user's manual at some point.
 ;; TODO: saving a scratch buffer should switch focus to the newly
 ;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart

--- a/mindstream.el
+++ b/mindstream.el
@@ -162,8 +162,15 @@ This also begins a new session."
   (interactive)
   ;; first write the existing scratch buffer
   ;; if there are unsaved changes
-  (mindstream-write)
-  (mindstream-iterate buffer-template))
+  (mindstream-iterate)
+  ;; clear the buffer
+  (erase-buffer)
+  ;; if the buffer was originally created using a template,
+  ;; then insert the template contents
+  (when buffer-template
+    (insert (mindstream--file-contents buffer-template)))
+  ;; write the fresh state
+  (mindstream-iterate))
 
 (defun mindstream--ab-initio-iterate (&optional template)
   "Create a scratch buffer for the first time."

--- a/mindstream.el
+++ b/mindstream.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/countvajhula/mindstream
 ;; Version: 0.0
-;; Package-Requires: ((emacs "25.1") (racket-mode "20220705.1452") (magit "3.3.0"))
+;; Package-Requires: ((emacs "25.1") (racket-mode "20210517.1613") (magit "3.3.0"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at
@@ -170,7 +170,8 @@ This also begins a new session."
   "Implicitly iterate the scratch buffer upon execution of some command.
 
 This only iterates the buffer if it is the current buffer and has been
-modified since the last persistent state. Otherwise, it takes no action.
+modified since the last persistent state.  Otherwise, it takes no
+action.
 
 ORIG-FN is the original function invoked, and ARGS are the arguments
 in that invocation."
@@ -185,7 +186,7 @@ in that invocation."
   "Save the current scratch buffer to a file.
 
 This is for interactive use only, for saving the file to a persistent
-location of your choice (i.e. FILENAME). To just save the file to its
+location of your choice (i.e. FILENAME).  To just save the file to its
 existing (tmp) location, use a low-level utility like `save-buffer` or
 `write-file` directly."
   (interactive (list (read-file-name "Save file as: " mindstream-save-file-path "")))
@@ -197,8 +198,9 @@ existing (tmp) location, use a low-level utility like `save-buffer` or
   "Save the current scratch session to a directory.
 
 If DEST-DIR is a non-existent path, it will be used as the name of a
-new directory that will contain the session. If it is an existing path,
-then the session will be saved at that path with its current name.
+new directory that will contain the session.  If it is an existing
+path, then the session will be saved at that path with its current
+name.
 
 It is advisable to use a descriptive name when saving a session, i.e.
 you would typically want to specify a new, non-existent folder."
@@ -238,9 +240,10 @@ DIR is the directory containing the session."
 If the scratch buffer doesn't exist, this creates a new one using
 the default configured template.
 
-This is a convenience utility for \"read only\" cases where we simply want to
-get the scratch buffer - whatever it may be. It is too connoted to be
-useful in features implementing the scratch buffer iteration model."
+This is a convenience utility for \"read only\" cases where we simply
+want to get the scratch buffer - whatever it may be. It is too
+connoted to be useful in features implementing the scratch buffer
+iteration model."
   (or (mindstream--get-anonymous-scratch-buffer)
       (mindstream-new mindstream-default-template)))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -52,6 +52,14 @@
       (mindstream-initialize)
     (mindstream-disable)))
 
+;; TODO:
+;; 1. There can only be one anonymous scratch session active at any time.
+;; 2. New sessions always begin as anonymous.
+;; 3. Named sessions may be loaded without interfering with the active
+;;    anonymous session.
+;; 4. Any number of named sessions could be active at the same time.
+;;    State should be maintained on the filesystem or in buffer-locals
+;;    (i.e. no global state) to keep named sessions self-contained and independent.
 ;; TODO: saving a scratch buffer should switch focus to the newly
 ;;       saved file but also preserve the scratch buffer (or clear it).
 ;; TODO: should there be a distinct notion of "session" apart

--- a/mindstream.el
+++ b/mindstream.el
@@ -31,6 +31,7 @@
 
 (require 'mindstream-custom)
 (require 'mindstream-scratch)
+(require 'mindstream-util)
 
 ;;;###autoload
 (define-minor-mode mindstream-mode
@@ -93,12 +94,6 @@
 ;;       (define an execution loop that is decoupled from the
 ;;       current buffer)
 
-(cl-defun mindstream--execute-shell-command (command &optional directory)
-  "Execute COMMAND at DIRECTORY and return its output."
-  (let ((default-directory (or directory
-                               (file-name-directory (buffer-file-name)))))
-    (shell-command-to-string command)))
-
 (defun mindstream--commit ()
   "Commit the current state as part of iteration."
   (mindstream--execute-shell-command "git add -A && git commit -a --allow-empty-message -m ''"))
@@ -147,6 +142,7 @@ This also begins a new session."
   (let ((buf (mindstream-start-session template)))
     ;; (ab initio) iterate
     (with-current-buffer buf
+      (mindstream-mode 1)
       (mindstream--iterate))
     (switch-to-buffer buf)))
 
@@ -273,6 +269,24 @@ you would typically want to specify a new, non-existent folder."
                     dir)))
     (find-file filename)
     (setq mindstream-session-name session)))
+
+(defun mindstream--get-or-create-scratch-buffer ()
+  "Get the active scratch buffer or create a new one.
+
+If the scratch buffer doesn't exist, this creates a new one using
+the default configured template.
+
+This is a convenience utility for \"read only\" cases where we simply want to
+get the scratch buffer - whatever it may be. It is too connoted to be
+useful in features implementing the scratch buffer iteration model."
+  (or (mindstream--get-anonymous-scratch-buffer)
+      (mindstream-new mindstream-default-template)))
+
+(defun mindstream-switch-to-scratch-buffer ()
+  "Switch to the anonymous scratch buffer."
+  (interactive)
+  (let ((buf (mindstream--get-or-create-scratch-buffer)))
+    (switch-to-buffer buf)))
 
 (provide 'mindstream)
 ;;; mindstream.el ends here

--- a/mindstream.el
+++ b/mindstream.el
@@ -134,7 +134,7 @@ a named session that you may happen to be visiting."
         (kill-buffer)))))
 
 (defun mindstream-new (template)
-  "Start a new scratch buffer using a specific template.
+  "Start a new scratch buffer using a specific TEMPLATE.
 
 This also begins a new session."
   (interactive (list (read-file-name "Which template? " mindstream-template-path)))
@@ -218,7 +218,10 @@ backwards in the scratch buffer history."
   "Implicitly iterate the scratch buffer upon execution of some command.
 
 This only iterates the buffer if it is the current buffer and has been
-modified since the last persistent state. Otherwise, it takes no action."
+modified since the last persistent state. Otherwise, it takes no action.
+
+ORIG-FN is the original function invoked, and ARGS are the arguments
+in that invocation."
   (when (and mindstream-mode
              (or (buffer-modified-p)
                  (magit-anything-modified-p)))
@@ -230,9 +233,9 @@ modified since the last persistent state. Otherwise, it takes no action."
   "Save the current scratch buffer to a file.
 
 This is for interactive use only, for saving the file to a persistent
-location of your choice. To just save the file to its existing (tmp)
-location, use a low-level utility like `save-buffer` or `write-file`
-directly."
+location of your choice (i.e. FILENAME). To just save the file to its
+existing (tmp) location, use a low-level utility like `save-buffer` or
+`write-file` directly."
   (interactive (list (read-file-name "Save file as: " mindstream-save-file-path "")))
   (unless mindstream-mode
     (error "Not a mindstream buffer!"))
@@ -262,7 +265,9 @@ you would typically want to specify a new, non-existent folder."
       (mindstream-load-session (concat dest-dir original-session-name)))))
 
 (defun mindstream-load-session (dir)
-  "Load a session from a directory."
+  "Load a session from a directory.
+
+DIR is the directory containing the session."
   (interactive (list (read-directory-name "Load session: " mindstream-save-session-path)))
   ;; restore the old session
   (let* ((session (file-name-nondirectory

--- a/mindstream.el
+++ b/mindstream.el
@@ -165,8 +165,8 @@ This also begins a new session."
   (erase-buffer)
   ;; if the buffer was originally created using a template,
   ;; then insert the template contents
-  (when buffer-template
-    (insert (mindstream--file-contents buffer-template)))
+  (when mindstream-template-used
+    (insert (mindstream--file-contents mindstream-template-used)))
   ;; write the fresh state
   (mindstream--iterate))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -118,17 +118,22 @@ it should typically be run using `with-current-buffer`."
    (file-name-base
     (buffer-file-name buffer))))
 
-(defun mindstream-new (template)
-  "Start a new scratch buffer using a specific template.
-
-This also begins a new session."
-  (interactive (list (read-file-name "Which template? " mindstream-template-path)))
+(defun mindstream--end-session ()
+  "End an active session."
   (with-current-buffer (mindstream--get-scratch-buffer)
     ;; first write the existing scratch buffer
     ;; if there are unsaved changes
     (mindstream-write)
     ;; then kill it
-    (kill-buffer))
+    (kill-buffer)))
+
+(defun mindstream-new (template)
+  "Start a new scratch buffer using a specific template.
+
+This also begins a new session."
+  (interactive (list (read-file-name "Which template? " mindstream-template-path)))
+  ;; end the current session
+  (mindstream--end-session)
   ;; start a new session
   (mindstream-start-session)
   ;; (ab initio) iterate
@@ -247,15 +252,9 @@ directly."
 (defun mindstream-load-session (dir)
   "Load a session from a directory."
   (interactive (list (read-directory-name "Load session: " mindstream-save-session-path)))
-  ;; save and delete existing scratch buffer
-  ;; open scratch file
-  ;; rename it to scratch
-  (with-current-buffer (mindstream--get-scratch-buffer)
-    ;; first write the existing scratch buffer
-    ;; if there are unsaved changes
-    (mindstream-write)
-    ;; then kill it
-    (kill-buffer))
+  ;; end the current session
+  (mindstream--end-session)
+  ;; restore the old session
   (let* ((session (file-name-nondirectory
                    (string-trim default-directory "" "/")))
          (filename (concat dir


### PR DESCRIPTION
### Summary of Changes

Use git for versioning instead of manually managed version indexes in separate files. This represents a much more robust model for "changes" giving us a ton more flexibility and features for free (e.g. ability to use any Git tools like Magit, git-timemachine, etc.). It will also allow nonlinear navigation of the change history (a la Vim Undotree) which is richer and more useful than a linearized (Emacs undo style) change model.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
