### PR TITLE
Generalized sessions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,11 @@
 mindstream
 ==========
 
-A rapid prototyping UX for Racket programming in Emacs, based on versioned and sessioned "scratch" buffers.
+Versioned and sessioned scratch buffers for freewriting text and exploratory programming in your favorite language, in Emacs.
 
-Every mindstream session is represented as a unique Git repository on disk. The Git repo contains commits representing the stages in your development process, bounded either by ``racket-run`` invocations, or by calls to ``mindstream-clear`` which restores the buffer to a "clear" state, i.e. to its original template form. You can save and load these sessions, too.
+Every mindstream session begins from a template you provide and evolves through the stages of your creative process. The session is stored as a unique Git repository on disk. The Git repo contains commits representing the stages in your development process bounded at natural points -- by default, the points at which your buffer is saved (whether explicitly by you or implicitly on running a command like ``racket-run`` or ``mindstream-clear``). You can save and load these sessions, too.
 
-In the future, this package may be generalized for use with other languages and in authoring settings in general.
+Typical uses of this package are for early stages of prototyping in a software project, or for exporatory programming to understand a new idea, tool, or technology. It's also great for just taking quick notes or freewriting blog posts or content in authoring settings in general.
 
 Installation
 ============
@@ -33,11 +33,25 @@ Usage
 If you'd like to try it out, follow these steps:
 
 1. Follow the installation instructions above to install this package using straight.el
-2. Ensure ``(mindstream-initialize)`` is somewhere in your config. This advises Racket Mode's ``racket-run`` to "iterate" the scratch buffer, providing implicit versioning for your Racket scratch buffer.
-3. Run ``mindstream-new`` to create a Racket scratch buffer.
-4. Hack away!
+2. Ensure ``(mindstream-initialize)`` is somewhere in your config. This advises "trigger" functions such as ``save-buffer`` to "iterate" the scratch buffer, providing implicit versioning for your session.
+3. Create a new template at ``~/.mindstream/templates/`` for your favorite programming language (or just plain text).
+4. Run ``mindstream-new`` to create a session.
+5. Hack away!
 
-You can also explore adding new templates in ``mindstream-template-path`` (default: ``"~/.mindstream/templates/"``) -- ordinary Racket files -- which will then be available as options in ``mindstream-new``. You can also save scratch buffers that you'd like to keep, or even entire scratch buffer sessions (which clones the mindstream Git repo to a location you specify).
+Adding New Session Templates
+----------------------------
+
+Mindstream doesn't include any templates out of the box, so you'll probably want to create some for standard scratch sessions you are likely to need, for instance, for programming in your favorite language (perhaps Racket?), or just freewriting some text for your next great novel, following in the keystrokes of Emacs octopuses like Neal Stephenson.
+
+You can add new templates in ``mindstream-template-path`` (default: ``"~/.mindstream/templates/"``) -- ordinary text files with any extension you like (e.g. ``.txt``, ``.rkt``, ``.el``, anything) -- which will then be available as options in ``mindstream-new``.
+
+Saving Sessions
+---------------
+
+You can also save scratch sessions that you'd like to keep by using ``mindstream-save-session`` (default binding: ``C-c C-r C-s``). This simply clones the session's Git repo to a more permanent and familiar path that you indicate (as opposed to the anonymous session path which is assumed to be temporary and defaults to ``/var/tmp/mindstream/``), thus preserving the entire session history, allowing it to be navigated and even resumed at any time in the future.
+
+Explore
+-------
 
 Try ``M-x mindstream- ...`` to see all the available interactive commands. These are also included as keybindings in a minor mode -- ``mindstream-mode`` -- which is enabled locally in scratch buffers.
 
@@ -46,7 +60,7 @@ Design
 
 Mindstream structures your workflow in sessions, which are version-controlled files. When you first start a session it begins as anonymous, meaning that it doesn't have a name. If the session develops into something worth keeping, you can save it to a preconfigured (or any) location on disk by giving the session a name. A session is stored as a version-controlled folder. You can also save just the file rather than the entire session. With that in mind, here are some properties of the design:
 
-1. There is only one anonymous scratch session active at any time.
+1. There is only one anonymous scratch session active at any time, per major mode.
 2. Saving an anonymous session turns it into a named session, and there is no active anonymous session at that point. Named sessions work the same as anonymous sessions aside from having a name and being in a permanent location on disk. A new anonymous session could be started at any time via `mindstream-new`.
 3. New sessions always begin as anonymous.
 4. Named sessions may be loaded without interfering with the active anonymous session.
@@ -65,7 +79,7 @@ Magit is useful to navigate the states in the session and see diffs representing
 Git-Timemachine
 ---------------
 
-The git-timemachine Emacs package is a great way to temporally navigate your session. Unlike the usual undo and redo operations which track edits with high granularity, mindstream sessions are bounded by ``racket-run`` invocations which tend to represent natural, distinct stages in your development. Mindstream doesn't include a built-in way to navigate these states, but you can use the git-timemachine package to do this (in read-only mode).
+The git-timemachine Emacs package is a great way to temporally navigate your session. Unlike the usual undo and redo operations which track edits with high granularity, mindstream sessions are bounded by ``save-buffer`` invocations which tend to represent natural, distinct stages in your development. Mindstream doesn't include a built-in way to navigate these states, but you can use the git-timemachine package to do this (in read-only mode).
 
 Acknowledgements
 ================

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -67,20 +67,15 @@
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-default-template-name "text.txt"
-  "Name for the default template that will be created when no templates exist."
+(defcustom mindstream-default-template "text.txt"
+  "Default template to use for new mindstream sessions.
+
+If no templates exist, this one will be created with the default template contents."
   :type 'string
   :group 'mindstream)
 
 (defcustom mindstream-default-template-contents "Welcome to Mindstream!\n\nOnce you're familiar with the basic functionality, you may want to modify this template to suit your needs, or add other templates of your own.\n\n"
   "Contents of the default template that is created if none exist."
-  :type 'string
-  :group 'mindstream)
-
-(defcustom mindstream-default-template
-  (concat (file-name-as-directory mindstream-template-path)
-          mindstream-default-template-name)
-  "Default template to use for new mindstream sessions."
   :type 'string
   :group 'mindstream)
 

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -57,11 +57,6 @@
   :type 'list
   :group 'mindstream)
 
-(defcustom mindstream-file-extension ".rkt"
-  "File extension to use for mindstream buffers."
-  :type 'string
-  :group 'mindstream)
-
 (defcustom mindstream-filename "scratch"
   "Filename to use for mindstream buffers."
   :type 'string

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -67,7 +67,7 @@
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-anonymous-buffer-name "*scratch - Racket*"
+(defcustom mindstream-anonymous-buffer-name "*scratch - Mindstream*"
   "The name of the mindstream scratch buffer."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -32,7 +32,7 @@
   "A scratch buffer."
   :group 'Editing)
 
-(defcustom mindstream-path "/var/tmp/racket/" ; TODO: make platform-independent?
+(defcustom mindstream-path "/var/tmp/mindstream/" ; TODO: make platform-independent?
   "Directory path where mindstream buffers will be saved during development."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -62,8 +62,8 @@
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-anonymous-buffer-name "*scratch - Mindstream*"
-  "The name of the mindstream scratch buffer."
+(defcustom mindstream-anonymous-buffer-prefix "scratch"
+  "The prefix to use in the name of a mindstream scratch buffer."
   :type 'string
   :group 'mindstream)
 

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -69,7 +69,7 @@ If no templates exist, this one will be created with the default template conten
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-default-template-contents "Welcome to Mindstream!\n\nOnce you're familiar with the basic functionality, you may want to modify this template to suit your needs, or add other templates of your own.\n\n"
+(defcustom mindstream-default-template-contents "The past is a memory, the future a dream, and now's a dance.\n"
   "Contents of the default template that is created if none exist."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -42,11 +42,6 @@
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-save-file-path mindstream--user-home-directory
-  "Default directory path for saving mindstream buffers."
-  :type 'string
-  :group 'mindstream)
-
 (defcustom mindstream-save-session-path mindstream--user-home-directory
   "Default directory path for saving mindstream sessions."
   :type 'string

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -52,6 +52,11 @@
   :type 'string
   :group 'mindstream)
 
+(defcustom mindstream-triggers (list #'save-buffer)
+  "Functions that, when called, should implicitly iterate the mindstream buffer."
+  :type 'list
+  :group 'mindstream)
+
 (defcustom mindstream-major-mode 'racket-mode
   "Major mode to use in mindstream buffers."
   :type 'string

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -57,11 +57,6 @@
   :type 'list
   :group 'mindstream)
 
-(defcustom mindstream-major-mode 'racket-mode
-  "Major mode to use in mindstream buffers."
-  :type 'string
-  :group 'mindstream)
-
 (defcustom mindstream-file-extension ".rkt"
   "File extension to use for mindstream buffers."
   :type 'string
@@ -77,8 +72,13 @@
   :type 'string
   :group 'mindstream)
 
-(defcustom mindstream-default-template-name "racket.rkt"
+(defcustom mindstream-default-template-name "text.txt"
   "Name for the default template that will be created when no templates exist."
+  :type 'string
+  :group 'mindstream)
+
+(defcustom mindstream-default-template-contents "Welcome to Mindstream!\n\nOnce you're familiar with the basic functionality, you may want to modify this template to suit your needs, or add other templates of your own.\n\n"
+  "Contents of the default template that is created if none exist."
   :type 'string
   :group 'mindstream)
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -80,13 +80,19 @@ New sessions always start anonymous."
   (concat (file-name-as-directory mindstream-path)
           (file-name-as-directory session)))
 
+(defun mindstream--template (&optional name)
+  "Path to template NAME.
+
+If NAME isn't provided, use the default template."
+  (concat (file-name-as-directory mindstream-template-path)
+          (or name mindstream-default-template)))
+
 (defun mindstream--ensure-templates-exist ()
   "Ensure that the templates directory exists and contains the default template."
   ;; consider alternative: an initialization function to do this the first time
   (unless (file-directory-p mindstream-template-path)
     (mkdir mindstream-template-path t))
-  (let ((default-template-file (concat mindstream-template-path
-                                       mindstream-default-template-name)))
+  (let ((default-template-file (mindstream--template)))
     (unless (file-exists-p default-template-file)
       (let ((buf (generate-new-buffer "default-template")))
         (with-current-buffer buf
@@ -127,6 +133,14 @@ if Emacs is exited."
       (insert contents)
       (mindstream--initialize-buffer major-mode-to-use))
     buf))
+
+(defun mindstream--infer-template ()
+  "Infer template to use based on current major mode."
+  ;; TODO: allow this to be customizable, a user-configured hash
+  (cond ((equal 'racket-mode major-mode) "racket.rkt")
+        ((equal 'emacs-lisp-mode major-mode) "elisp.el")
+        ((equal 'text-mode major-mode) "text.txt")
+        (t (error "Unknown major mode!"))))
 
 (defun mindstream--infer-major-mode (file)
   "Infer a major mode to use based on the file extension."

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -108,15 +108,14 @@ New sessions always start anonymous."
 This sets the major mode and any other necessary attributes."
   ;; TODO: instead of hardcoding the major mode, just let Emacs
   ;; choose it based on the file extension
-  (let ((major-mode-to-use mindstream-major-mode))
-    (unless (eq major-mode major-mode-to-use)
-      (funcall major-mode-to-use))
-    (setq buffer-offer-save nil)
-    ;; Ignore whatever `racket-repl-buffer-name-function' just did to
-    ;; set `racket-repl-buffer-name' and give this its own REPL.
-    (setq-local racket-repl-buffer-name "*scratch - Racket REPL*")
-    ;; place point at the end of the buffer
-    (goto-char (point-max))))
+  (unless (eq major-mode mindstream-major-mode)
+    (funcall mindstream-major-mode))
+  (setq buffer-offer-save nil)
+  ;; Ignore whatever `racket-repl-buffer-name-function' just did to
+  ;; set `racket-repl-buffer-name' and give this its own REPL.
+  (setq-local racket-repl-buffer-name "*scratch - Racket REPL*")
+  ;; place point at the end of the buffer
+  (goto-char (point-max)))
 
 (defun mindstream--new-buffer-with-contents (contents)
   "Create a new scratch buffer containing CONTENTS.

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -62,8 +62,10 @@ New sessions always start anonymous."
          (template (or template mindstream-default-template))
          (file-extension (file-name-extension template))
          (buf (mindstream--new-buffer-from-template template))
+         ;; TODO: use platform-independent path construction
          (filename (concat base-path
                            mindstream-filename
+                           "."
                            file-extension)))
     (unless (file-directory-p base-path)
       (mkdir base-path t)

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -140,6 +140,7 @@ if Emacs is exited."
   (cond ((equal 'racket-mode major-mode) "racket.rkt")
         ((equal 'emacs-lisp-mode major-mode) "elisp.el")
         ((equal 'text-mode major-mode) "text.txt")
+        ((equal 'markdown-mode major-mode) "markdown.md")
         ((equal 'python-mode major-mode) "python.py")
         (t (error "Unknown major mode!"))))
 
@@ -150,6 +151,7 @@ if Emacs is exited."
     (cond ((equal "rkt" extension) #'racket-mode)
           ((equal "el" extension) #'emacs-lisp-mode)
           ((equal "txt" extension) #'text-mode)
+          ((equal "md" extension) #'markdown-mode)
           ((equal "py" extension) #'python-mode)
           (t (error "Unknown template extension!")))))
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -133,6 +133,7 @@ if Emacs is exited."
   (let ((extension (file-name-extension file)))
     ;; TODO: use `auto-mode-alist` instead?
     (cond ((equal "rkt" extension) #'racket-mode)
+          ((equal "el" extension) #'emacs-lisp-mode)
           ((equal "txt" extension) #'text-mode)
           (t (error "Unknown template extension!")))))
 

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -91,7 +91,7 @@ New sessions always start anonymous."
     (mkdir mindstream-template-path t)
     (let ((buf (generate-new-buffer "default-template")))
       (with-current-buffer buf
-        (insert "#lang racket\n\n")
+        (insert mindstream-default-template-contents)
         (write-file (concat mindstream-template-path
                             mindstream-default-template-name)))
       (kill-buffer buf))))

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -140,6 +140,7 @@ if Emacs is exited."
   (cond ((equal 'racket-mode major-mode) "racket.rkt")
         ((equal 'emacs-lisp-mode major-mode) "elisp.el")
         ((equal 'text-mode major-mode) "text.txt")
+        ((equal 'python-mode major-mode) "python.py")
         (t (error "Unknown major mode!"))))
 
 (defun mindstream--infer-major-mode (file)
@@ -149,6 +150,7 @@ if Emacs is exited."
     (cond ((equal "rkt" extension) #'racket-mode)
           ((equal "el" extension) #'emacs-lisp-mode)
           ((equal "txt" extension) #'text-mode)
+          ((equal "py" extension) #'python-mode)
           (t (error "Unknown template extension!")))))
 
 (defun mindstream--new-buffer-from-template (template)

--- a/mindstream-scratch.el
+++ b/mindstream-scratch.el
@@ -84,13 +84,15 @@ New sessions always start anonymous."
   "Ensure that the templates directory exists and contains the default template."
   ;; consider alternative: an initialization function to do this the first time
   (unless (file-directory-p mindstream-template-path)
-    (mkdir mindstream-template-path t)
-    (let ((buf (generate-new-buffer "default-template")))
-      (with-current-buffer buf
-        (insert mindstream-default-template-contents)
-        (write-file (concat mindstream-template-path
-                            mindstream-default-template-name)))
-      (kill-buffer buf))))
+    (mkdir mindstream-template-path t))
+  (let ((default-template-file (concat mindstream-template-path
+                                       mindstream-default-template-name)))
+    (unless (file-exists-p default-template-file)
+      (let ((buf (generate-new-buffer "default-template")))
+        (with-current-buffer buf
+          (insert mindstream-default-template-contents)
+          (write-file default-template-file))
+        (kill-buffer buf)))))
 
 (defun mindstream--file-contents (filename)
   "Get contents of FILENAME as a string."

--- a/mindstream.el
+++ b/mindstream.el
@@ -48,8 +48,8 @@
   (let ((mindstream-map (make-sparse-keymap)))
     (define-key mindstream-map (kbd "C-c C-r n") #'mindstream-new)
     (define-key mindstream-map (kbd "C-c C-r c") #'mindstream-clear)
-    (define-key mindstream-map (kbd "C-c C-r s") #'mindstream-save-file)
-    (define-key mindstream-map (kbd "C-c C-r S") #'mindstream-save-session)
+    (define-key mindstream-map (kbd "C-c C-r s") #'mindstream-save-session)
+    (define-key mindstream-map (kbd "C-c C-r C-s") #'mindstream-save-session)
     (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
     mindstream-map))
 
@@ -138,19 +138,6 @@ in that invocation."
                (magit-anything-modified-p))
       (mindstream--iterate))
     result))
-
-(defun mindstream-save-file (filename)
-  "Save the current scratch buffer to a file.
-
-This is for interactive use only, for saving the file to a persistent
-location of your choice (i.e. FILENAME).  To just save the file to its
-existing (tmp) location, use a low-level utility like `save-buffer` or
-`write-file` directly."
-  (interactive (list (read-file-name "Save file as: " mindstream-save-file-path "")))
-  (save-buffer)  ; ensure it saves any WIP
-  (write-file filename)
-  ;; since it's a standalone file, there is no session and versioning (i.e. git)
-  (mindstream-mode -1))
 
 (defun mindstream--session-name ()
   "Name of the current session.

--- a/mindstream.el
+++ b/mindstream.el
@@ -103,6 +103,7 @@ This also begins a new session."
     (error "Not a mindstream buffer!"))
   ;; first write the existing scratch buffer
   ;; if there are unsaved changes
+  (save-buffer)
   (mindstream--iterate)
   ;; clear the buffer
   (erase-buffer)

--- a/mindstream.el
+++ b/mindstream.el
@@ -69,7 +69,7 @@ it should typically be run using `with-current-buffer`."
       (rename-buffer mindstream-anonymous-buffer-name))
     (mindstream--commit)))
 
-(defun mindstream--end-session ()
+(defun mindstream--end-anonymous-session ()
   "End the current anonymous session.
 
 This always affects the current anonymous session and does not affect
@@ -88,7 +88,7 @@ a named session that you may happen to be visiting."
 
 This also begins a new session."
   ;; end the current anonymous session
-  (mindstream--end-session)
+  (mindstream--end-anonymous-session)
   ;; start a new session (sessions always start anonymous)
   (let ((buf (mindstream-start-session template)))
     ;; (ab initio) iterate
@@ -194,7 +194,7 @@ you would typically want to specify a new, non-existent folder."
     ;; TODO: verify behavior with existing vs non-existent containing folder
     (copy-directory (file-name-directory (buffer-file-name))
                     dest-dir)
-    (mindstream--end-session)
+    (mindstream--end-anonymous-session)
     (if named
         (mindstream-load-session dest-dir)
       (mindstream-load-session (concat dest-dir original-session-name)))))

--- a/mindstream.el
+++ b/mindstream.el
@@ -147,10 +147,9 @@ location of your choice (i.e. FILENAME).  To just save the file to its
 existing (tmp) location, use a low-level utility like `save-buffer` or
 `write-file` directly."
   (interactive (list (read-file-name "Save file as: " mindstream-save-file-path "")))
-  (unless mindstream-mode
-    (error "Not a mindstream buffer!"))
   (save-buffer)  ; ensure it saves any WIP
   (write-file filename)
+  ;; since it's a standalone file, there is no session and versioning (i.e. git)
   (mindstream-mode -1))
 
 (defun mindstream--session-name ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -164,10 +164,10 @@ you would typically want to specify a new, non-existent folder."
     (error "Not a mindstream buffer!"))
   (save-buffer) ; ensure it saves any WIP
   ;; The chosen name of the directory becomes the name of the session.
-  (let ((original-session-name (mindstream--session-name))
-        (buffer-file (buffer-file-name))
-        (filename (file-name-nondirectory (buffer-file-name)))
-        (named (not (file-directory-p dest-dir))))
+  (let* ((original-session-name (mindstream--session-name))
+         (buffer-file (buffer-file-name))
+         (filename (file-name-nondirectory buffer-file))
+         (named (not (file-directory-p dest-dir))))
     ;; ensure no unsaved changes
     ;; note: this is a no-op if save-buffer is a trigger for iteration
     (mindstream--iterate)
@@ -177,11 +177,9 @@ you would typically want to specify a new, non-existent folder."
     (mindstream--end-anonymous-session)
     ;; TODO: platform-independent paths
     (if named
-        (mindstream-load-session (concat (file-name-as-directory dest-dir)
-                                         filename))
+        (mindstream-load-session dest-dir)
       (mindstream-load-session (concat (file-name-as-directory dest-dir)
-                                       (file-name-as-directory original-session-name)
-                                       filename)))))
+                                       original-session-name)))))
 
 (defun mindstream--session-file-p (file)
   "Predicate to identify whether FILE is a Mindstream session file."

--- a/mindstream.el
+++ b/mindstream.el
@@ -183,14 +183,25 @@ you would typically want to specify a new, non-existent folder."
                                        (file-name-as-directory original-session-name)
                                        filename)))))
 
-(defun mindstream-load-session (filename)
+(defun mindstream--session-file-p (file)
+  "Predicate to identify whether FILE is a Mindstream session file."
+  (string-match-p
+   (concat "^"
+           mindstream-filename)
+   file))
+
+(defun mindstream-load-session (dir)
   "Load a session from a directory.
 
-FILENAME is the directory containing the session."
-  (interactive (list (read-file-name "Load session: " mindstream-save-session-path)))
+DIR is the directory containing the session."
+  (interactive (list (read-directory-name "Load session: " mindstream-save-session-path)))
   ;; restore the old session
-  (find-file filename)
-  (mindstream-mode 1))
+  (let ((filename (expand-file-name
+                   (seq-find #'mindstream--session-file-p
+				             (directory-files dir))
+                   dir)))
+    (find-file filename)
+    (mindstream-mode 1)))
 
 (defun mindstream--get-or-create-scratch-buffer ()
   "Get the active scratch buffer or create a new one.

--- a/mindstream.el
+++ b/mindstream.el
@@ -225,7 +225,8 @@ want to get the scratch buffer - whatever it may be. It is too
 connoted to be useful in features implementing the scratch buffer
 iteration model."
   (or (mindstream--get-anonymous-scratch-buffer)
-      (mindstream--new mindstream-default-template)))
+      (mindstream--new (mindstream--template
+                        (mindstream--infer-template)))))
 
 (defun mindstream-switch-to-scratch-buffer ()
   "Switch to the anonymous scratch buffer."

--- a/mindstream.el
+++ b/mindstream.el
@@ -53,21 +53,12 @@
     (define-key mindstream-map (kbd "C-c C-r r") #'mindstream-load-session)
     mindstream-map))
 
-(defun mindstream--commit ()
-  "Commit the current state as part of iteration."
-  (mindstream--execute-shell-command "git add -A && git commit -a --allow-empty-message -m ''"))
-
 (defun mindstream--iterate ()
-  "Write scratch buffer to disk and increment the version.
-
-This assumes that the scratch buffer is the current buffer, so
-it should typically be run using `with-current-buffer`."
-  (let ((anonymous (mindstream-anonymous-scratch-buffer-p)))
-    ;; writing the file changes the buffer name to the filename,
-    ;; so we restore the original buffer name
-    (when anonymous
-      (rename-buffer mindstream-anonymous-buffer-name))
-    (mindstream--commit)))
+  "Commit the current state as part of iteration."
+  (mindstream--execute-shell-command
+   (concat "git add -A"
+           " && "
+           "git commit -a --allow-empty-message -m ''")))
 
 (defun mindstream--end-anonymous-session ()
   "End the current anonymous session.
@@ -226,7 +217,7 @@ connoted to be useful in features implementing the scratch buffer
 iteration model."
   (or (mindstream--get-anonymous-scratch-buffer)
       (mindstream--new (mindstream--template
-                        (mindstream--infer-template)))))
+                        (mindstream--infer-template major-mode)))))
 
 (defun mindstream-switch-to-scratch-buffer ()
   "Switch to the anonymous scratch buffer."

--- a/mindstream.el
+++ b/mindstream.el
@@ -199,8 +199,11 @@ you would typically want to specify a new, non-existent folder."
     (mindstream--end-anonymous-session)
     ;; TODO: platform-independent paths
     (if named
-        (mindstream-load-session (concat dest-dir "/" filename))
-      (mindstream-load-session (concat dest-dir "/" original-session-name "/" filename)))))
+        (mindstream-load-session (concat (file-name-as-directory dest-dir)
+                                         filename))
+      (mindstream-load-session (concat (file-name-as-directory dest-dir)
+                                       (file-name-as-directory original-session-name)
+                                       filename)))))
 
 (defun mindstream-load-session (filename)
   "Load a session from a directory.

--- a/mindstream.el
+++ b/mindstream.el
@@ -125,11 +125,13 @@ This also begins a new session."
 ;;;###autoload
 (defun mindstream-initialize ()
   "Advise any functions that should implicitly cause the scratch buffer to iterate."
-  (advice-add #'save-buffer :around #'mindstream-implicitly-iterate-advice))
+  (dolist (fn mindstream-triggers)
+    (advice-add fn :around #'mindstream-implicitly-iterate-advice)))
 
 (defun mindstream-disable ()
   "Remove any advice for racket scratch buffers."
-  (advice-remove #'save-buffer #'mindstream-implicitly-iterate-advice))
+  (dolist (fn mindstream-triggers)
+    (advice-remove fn #'mindstream-implicitly-iterate-advice)))
 
 (defun mindstream-implicitly-iterate-advice (orig-fn &rest args)
   "Implicitly iterate the scratch buffer upon execution of some command.

--- a/mindstream.el
+++ b/mindstream.el
@@ -187,17 +187,20 @@ you would typically want to specify a new, non-existent folder."
   (save-buffer) ; ensure it saves any WIP
   ;; The chosen name of the directory becomes the name of the session.
   (let ((original-session-name (mindstream--session-name))
+        (buffer-file (buffer-file-name))
+        (filename (file-name-nondirectory (buffer-file-name)))
         (named (not (file-directory-p dest-dir))))
     ;; ensure no unsaved changes
     ;; note: this is a no-op if save-buffer is a trigger for iteration
     (mindstream--iterate)
     ;; TODO: verify behavior with existing vs non-existent containing folder
-    (copy-directory (file-name-directory (buffer-file-name))
+    (copy-directory (file-name-directory buffer-file)
                     dest-dir)
     (mindstream--end-anonymous-session)
+    ;; TODO: platform-independent paths
     (if named
-        (mindstream-load-session dest-dir)
-      (mindstream-load-session (concat dest-dir original-session-name)))))
+        (mindstream-load-session (concat dest-dir "/" filename))
+      (mindstream-load-session (concat dest-dir "/" original-session-name "/" filename)))))
 
 (defun mindstream-load-session (filename)
   "Load a session from a directory.


### PR DESCRIPTION
### Summary of Changes

This decouples sessions from any particular major mode (such as Racket Mode), allowing users to use a scratch buffer for prototyping in any major mode and language, including basic text-based note taking.

Addresses #3 and #5.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
