### PR TITLE
Improving completion

### DIFF
--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -45,25 +45,25 @@
 
 (defcustom mindstream-path
   ;; platform-independent ~/.emacs.d/mindstream/anon
-  (mindstream--joindirs user-emacs-directory
-                        "mindstream"
-                        "anon")
+  (mindstream--build-path user-emacs-directory
+                          "mindstream"
+                          "anon")
   "Directory where anonymous mindstream sessions will be stored."
   :type 'string
   :group 'mindstream)
 
 (defcustom mindstream-template-path
   ;; platform-independent ~/.emacs.d/mindstream/templates
-  (mindstream--joindirs user-emacs-directory
-                        "mindstream"
-                        "templates")
+  (mindstream--build-path user-emacs-directory
+                          "mindstream"
+                          "templates")
   "Directory path where mindstream will look for templates."
   :type 'string
   :group 'mindstream)
 
 (defcustom mindstream-save-session-path
-  (mindstream--joindirs mindstream--user-home-directory
-                        "mindstream")
+  (mindstream--build-path mindstream--user-home-directory
+                          "mindstream")
   "Default directory path for saving mindstream sessions."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -61,12 +61,9 @@
   :type 'string
   :group 'mindstream)
 
-;; The default mindstream-save-session-path is the user home directory.
-;; This is too big for the directory files recursively used in
-;; `mindstream--completing-read-session'. A default of some other
-;; directory that is more contained is suggested.
-;; (setopt mindstream-save-session-path "~/.config/emacs/mindstream/")
-(defcustom mindstream-save-session-path mindstream--user-home-directory
+(defcustom mindstream-save-session-path
+  (mindstream--joindirs mindstream--user-home-directory
+                        "mindstream")
   "Default directory path for saving mindstream sessions."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -61,6 +61,11 @@
   :type 'string
   :group 'mindstream)
 
+;; The default mindstream-save-session-path is the user home directory.
+;; This is too big for the directory files recursively used in
+;; `mindstream--completing-read-session'. A default of some other
+;; directory that is more contained is suggested.
+;; (setopt mindstream-save-session-path "~/.config/emacs/mindstream/")
 (defcustom mindstream-save-session-path mindstream--user-home-directory
   "Default directory path for saving mindstream sessions."
   :type 'string

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -84,14 +84,6 @@
                 :value-type function)
   :group 'mindstream)
 
-(defcustom mindstream-starting-file nil
-  "The file to start the session, for each template.
-
-If no file is specified for a template, defaults to `mindstream-file'."
-  :type '(plist :key-type string
-                :value-type string)
-  :group 'mindstream)
-
 (defcustom mindstream-preferred-template nil
   "The preferred template for each major mode.
 
@@ -103,11 +95,6 @@ same extension, you may prefer to indicate which one is \"preferred\"
 for the major mode so that it would be selected."
   :type '(plist :key-type symbol
                 :value-type function)
-  :group 'mindstream)
-
-(defcustom mindstream-filename "scratch"
-  "Filename to use for mindstream buffers."
-  :type 'string
   :group 'mindstream)
 
 (defcustom mindstream-anonymous-buffer-prefix "scratch"

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -75,7 +75,8 @@ DIR is expected to be a path to an existing folder."
   "Begin a session at the current path."
   (interactive)
   (push default-directory mindstream-active-sessions)
-  (add-to-list 'mindstream-session-history default-directory)
+  (add-to-list 'mindstream-session-history
+               (mindstream--session-file-name-relative default-directory))
   (message "Session started at %s." default-directory))
 
 (defun mindstream-end-session (&optional session)

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -91,18 +91,18 @@ This only removes implicit versioning. It does not close any open
 buffers at the SESSION path."
   (interactive (list (completing-read "Which session? "
                                       mindstream-active-sessions
-                                      ;; This excludes all anonymous
-                                      ;; sessions, which we should be
-                                      ;; able to also end.
-
-                                      ;; (lambda (session)
-                                      ;;   (not
-                                      ;;    (string-prefix-p mindstream-path
-                                      ;;                     session)))
-                                      )))
-  ;; Since we have completing-read above, do we have a case when session
-  ;; is nil and use `mind-stream--curent-session' at all?
+                                      ;; We typically end sessions on existing
+                                      ;; projects to stop implicit versioning.
+                                      ;; Exclude anonymous sessions here since
+                                      ;; it's OK if those aren't ended (we can
+                                      ;; just forget about them and move on).
+                                      (lambda (session)
+                                        (not
+                                         (string-prefix-p mindstream-path
+                                                          session))))))
   (let ((session (or session (mindstream--current-session))))
+    ;; session can be nil if called non-interactively
+    ;; as in `mindstream--end-anonymous-session'
     (setq mindstream-active-sessions
           (remove session mindstream-active-sessions))
     (message "Session %s ended." session)))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -85,10 +85,17 @@ This only removes implicit versioning. It does not close any open
 buffers at the SESSION path."
   (interactive (list (completing-read "Which session? "
                                       mindstream-active-sessions
-                                      (lambda (session)
-                                        (not
-                                         (string-prefix-p mindstream-path
-                                                          session))))))
+                                      ;; This excludes all anonymous
+                                      ;; sessions, which we should be
+                                      ;; able to also end.
+
+                                      ;; (lambda (session)
+                                      ;;   (not
+                                      ;;    (string-prefix-p mindstream-path
+                                      ;;                     session)))
+                                      )))
+  ;; Since we have completing-read above, do we have a case when session
+  ;; is nil and use `mind-stream--curent-session' at all?
   (let ((session (or session (mindstream--current-session))))
     (setq mindstream-active-sessions
           (remove session mindstream-active-sessions))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -68,7 +68,11 @@ DIR is expected to be a path to an existing folder."
     (if (and files (= 1 (length files)))
         (car files)
       (completing-read "Which file? "
-                       files nil t nil
+                       (mapcar (lambda (f)
+                                 (mindstream--session-file-name-relative f
+                                                                         dir))
+                               files)
+                       nil t nil
                        mindstream-session-file-history))))
 
 (defun mindstream-begin-session ()
@@ -76,7 +80,8 @@ DIR is expected to be a path to an existing folder."
   (interactive)
   (push default-directory mindstream-active-sessions)
   (add-to-list 'mindstream-session-history
-               (mindstream--session-file-name-relative default-directory))
+               (mindstream--session-file-name-relative default-directory
+                                                       mindstream-save-session-path))
   (message "Session started at %s." default-directory))
 
 (defun mindstream-end-session (&optional session)

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -119,6 +119,10 @@ New sessions always start anonymous."
       (copy-directory template base-path)
       (mindstream-backend-initialize base-path)
       (let ((filename (mindstream--starting-file-for-session base-path)))
+        ;; end existing anonymous session for this major mode
+        (mindstream--end-anonymous-session
+         (mindstream--infer-major-mode
+          filename))
         (find-file
          (expand-file-name filename
                            base-path))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -167,15 +167,15 @@ New sessions always start anonymous."
 
 (defun mindstream--generate-anonymous-session-path (session)
   "A path on disk to use for a newly created SESSION."
-  (mindstream--joindirs mindstream-path
-                        session))
+  (mindstream--build-path mindstream-path
+                          session))
 
 (defun mindstream--template (&optional name)
   "Path to template NAME.
 
 If NAME isn't provided, use the default template."
-  (mindstream--joindirs mindstream-template-path
-                        (or name mindstream-default-template)))
+  (mindstream--build-path mindstream-template-path
+                          (or name mindstream-default-template)))
 
 (defun mindstream--ensure-anonymous-path ()
   "Ensure that the anonymous session path exists."
@@ -188,9 +188,9 @@ If NAME isn't provided, use the default template."
     (let ((default-template-dir (mindstream--template)))
       (mkdir default-template-dir t)
       (let ((template-file
-             (mindstream--joindirs default-template-dir
-                                   (concat mindstream-anonymous-buffer-prefix
-                                           ".txt"))))
+             (mindstream--build-path default-template-dir
+                                     (concat mindstream-anonymous-buffer-prefix
+                                             ".txt"))))
         (let ((buf (generate-new-buffer "default-template")))
           (with-current-buffer buf
             (insert mindstream-default-template-contents)

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -104,7 +104,7 @@ buffers at the SESSION path."
   (let ((path (or path default-directory)))
     (member path mindstream-active-sessions)))
 
-(defun mindstream-start-anonymous-session (&optional session-file)
+(defun mindstream-start-anonymous-session (&optional template)
   "Start a new anonymous session.
 
 This creates a new directory and Git repository for the new session
@@ -114,14 +114,11 @@ Otherwise, it uses the configured default template.
 New sessions always start anonymous."
   (let* ((session (mindstream--unique-name))
          (base-path (mindstream--generate-anonymous-session-path session))
-         (template (or (file-name-directory session-file)
-                       mindstream-default-template)))
+         (template (or template mindstream-default-template)))
     (unless (file-directory-p base-path)
       (copy-directory template base-path)
       (mindstream-backend-initialize base-path)
-      (let ((filename
-             (or session-file
-                 (mindstream--session-file-for-template template))))
+      (let ((filename (mindstream--starting-file-for-session base-path)))
         (find-file
          (expand-file-name filename
                            base-path))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -63,10 +63,12 @@ number of active sessions is likely to be small.")
 (defun mindstream--starting-file-for-session (dir)
   "Select an appropriate starting file for a session.
 
-DIR is expected to be a path to an existing folder."
+DIR is expected to be a path to an existing folder. This returns a
+filename relative to DIR rather than an absolute path."
   (let ((files (mindstream--directory-files-recursively dir)))
     (if (and files (= 1 (length files)))
-        (car files)
+        (mindstream--session-file-name-relative (car files)
+                                                dir)
       (completing-read "Which file? "
                        (mapcar (lambda (f)
                                  (mindstream--session-file-name-relative f

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -80,9 +80,9 @@ platform-appropriate way.
   "List files in DIR that aren't hidden or special."
   ;; TODO: exclude files that aren't versioned by Git
   (directory-files-recursively dir
-                               directory-files-no-dot-files-regexp
+                               "^[^\\.]"
                                nil
-                               ;; Exclude dotfiles
+                               ;; Exclude hidden directories like .git
                                (lambda (f)
                                  (not (string-match-p "/\\." f)))))
 

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -76,6 +76,16 @@ platform-appropriate way.
               (directory-files dir
                                nil)))
 
+(defun mindstream--directory-files-recursively (dir)
+  "List files in DIR that aren't hidden or special."
+  ;; TODO: exclude files that aren't versioned by Git
+  (directory-files-recursively dir
+                               directory-files-no-dot-files-regexp
+                               nil
+                               ;; Exclude dotfiles
+                               (lambda (f)
+                                 (not (string-match-p "/\\." f)))))
+
 (defun mindstream--directory-name (path)
   "The name of the directory at PATH."
   (file-name-nondirectory

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -53,17 +53,17 @@ This consults Emacs's `auto-mode-alist'."
           (throw 'return mode))))))
 
 ;; From: https://stackoverflow.com/a/13473856/323874
-(defun mindstream--joindirs (root &rest dirs)
+(defun mindstream--build-path (root &rest dirs)
   "Joins a series of directories together, like Python's os.path.join.
 
 This concatenates the ROOT path with the sequence of DIRS in the
 platform-appropriate way.
 
-  (mindstream--joindirs \"/tmp\" \"a\" \"b\" \"c\") => /tmp/a/b/c"
+  (mindstream--build-path \"/tmp\" \"a\" \"b\" \"c\") => /tmp/a/b/c"
 
   (if (not dirs)
       root
-    (apply #'mindstream--joindirs
+    (apply #'mindstream--build-path
            (expand-file-name (car dirs) root)
            (cdr dirs))))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -108,7 +108,7 @@ such that the last part of the name is mindstream template's name.
 For example:
 - FILENAME: /home/<user name>/.config/emacs/mindstream/templates/text
 - template: text"
-  (let ((template (car (last (string-split filename "/")))))
+  (let ((template (car (last (split-string filename "/")))))
     (cons template filename)))
 
 (defun mindstream--completing-read-template ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -53,7 +53,6 @@
 This is stored as a local variable in the session buffer so that it
 can be retrieved and canceled when you leave live mode.")
 
-(defvar mindstream-template-history nil)
 (defvar mindstream-template-file-history nil)
 
 ;;;###autoload

--- a/mindstream.el
+++ b/mindstream.el
@@ -298,30 +298,30 @@ the file to be opened."
 
 (defun mindstream--completing-read-session ()
   "Return session-file via completion for template."
-  ;; would like this to return a folder
-  (let* ((dirs
-          (thread-last
-            (directory-files-recursively
-             mindstream-save-session-path
-             directory-files-no-dot-files-regexp
-             :include-directories
-             (lambda (f) (and (file-directory-p f)
-                              ;; Exclude dotfiles
-                              (not (string-match-p "/\\." f)))))
-            (append mindstream-session-history)
-            ;; It's probably also good to delete sub-directories of
-            ;; anon. There will be too many.
-            (mapcar #'expand-file-name)
-            (delete-dups)
-            (mapcar (lambda (d)
-                      (if (string-match-p
-                           (expand-file-name mindstream-save-session-path) d)
-                          (file-relative-name d mindstream-save-session-path)
-                        (identity d))))))
-         (dir (completing-read "Which session? " dirs nil t nil
-                               'mindstream-session-history)))
+  ;; It's probably also good to delete sub-directories of
+  ;; anon. There will be too many.
+  (let* ((dirs-alist (mapcar
+                      (lambda (d)
+                        (cons d (mindstream--session-file-name-expand d)))
+                      mindstream-session-history))
+         (dir-key (completing-read "Which session? " dirs-alist nil t nil
+                                   'mindstream-session-history))
+         (dir (cdr (assoc-string dir-key dirs-alist))))
     ;; Return directory name
     (file-name-as-directory dir)))
+
+(defun mindstream--session-file-name-expand (file)
+  "Return fully expanded FILE name for `mindstream-session-history'."
+  (if (file-name-absolute-p file)
+      (expand-file-name file)
+    (expand-file-name file mindstream-save-session-path)))
+
+(defun mindstream--session-file-name-relative (file)
+  "Return relative FILE name for `mindstream-session-history'."
+  (if (string-match-p
+       (expand-file-name mindstream-save-session-path) file)
+      (file-relative-name file mindstream-save-session-path)
+    (abbreviate-file-name file)))
 
 (defun mindstream--get-or-create-session ()
   "Get the anonymous session buffer or create a new one.

--- a/mindstream.el
+++ b/mindstream.el
@@ -318,14 +318,16 @@ the file to be opened."
 (defun mindstream--session-file-name-expand (file)
   "Return fully expanded FILE name for `mindstream-session-history'."
   (if (file-name-absolute-p file)
-      (expand-file-name file)
+      file  ; (expand-file-name file) - probably don't need to expand if absolute?
     (expand-file-name file mindstream-save-session-path)))
 
-(defun mindstream--session-file-name-relative (file)
-  "Return relative FILE name for `mindstream-session-history'."
+(defun mindstream--session-file-name-relative (file dir)
+  "Return relative FILE name for `mindstream-session-history'.
+
+This returns a path of FILE relative to DIR."
   (if (string-match-p
-       (expand-file-name mindstream-save-session-path) file)
-      (file-relative-name file mindstream-save-session-path)
+       (expand-file-name dir) file)
+      (file-relative-name file dir)
     (abbreviate-file-name file)))
 
 (defun mindstream--get-or-create-session ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -312,7 +312,12 @@ the file to be opened."
             ;; It's probably also good to delete sub-directories of
             ;; anon. There will be too many.
             (mapcar #'expand-file-name)
-            (delete-dups)))
+            (delete-dups)
+            (mapcar (lambda (d)
+                      (if (string-match-p
+                           (expand-file-name mindstream-save-session-path) d)
+                          (file-relative-name d mindstream-save-session-path)
+                        (identity d))))))
          (dir (completing-read "Which session? " dirs nil t nil
                                'mindstream-session-history)))
     ;; Return directory name

--- a/mindstream.el
+++ b/mindstream.el
@@ -285,16 +285,15 @@ will be opened upon loading the session.  Otherwise, follow the default
 protocol for selecting a file, including, if necessary, prompting for
 the file to be opened."
   (interactive (list ;; TODO: use completing-read-session
-                (read-directory-name "Load session: "
-                                     mindstream-save-session-path
-                                     nil
-                                     t
-                                     "")))
+                (mindstream--completing-read-session)))
   (let ((file (or file
                   (mindstream--starting-file-for-session dir))))
-    (find-file
-     (expand-file-name file
-                       dir))
+    (find-file file)
+    ;; `expand-file-name' appears to be redundant as
+    ;; `mindstream--directory-files-recursively' uses
+    ;; `directory-files-recursively', which returns file name in its
+    ;; absolute form.
+    ;; (expand-file-name file dir))
     (mindstream-begin-session)))
 
 (defun mindstream--completing-read-session ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -53,8 +53,6 @@
 This is stored as a local variable in the session buffer so that it
 can be retrieved and canceled when you leave live mode.")
 
-(defvar mindstream-template-file-history nil)
-
 ;;;###autoload
 (define-minor-mode mindstream-mode
   "Minor mode providing global keybindings for mindstream mode."

--- a/mindstream.el
+++ b/mindstream.el
@@ -288,12 +288,7 @@ the file to be opened."
                 (mindstream--completing-read-session)))
   (let ((file (or file
                   (mindstream--starting-file-for-session dir))))
-    (find-file file)
-    ;; `expand-file-name' appears to be redundant as
-    ;; `mindstream--directory-files-recursively' uses
-    ;; `directory-files-recursively', which returns file name in its
-    ;; absolute form.
-    ;; (expand-file-name file dir))
+    (find-file (expand-file-name file dir))
     (mindstream-begin-session)))
 
 (defun mindstream--completing-read-session ()
@@ -332,9 +327,12 @@ the file to be opened."
 (defun mindstream--session-file-name-relative (file dir)
   "Return relative FILE name for `mindstream-session-history'.
 
-This returns a path of FILE relative to DIR."
+This returns the path of FILE relative to DIR if FILE is in DIR,
+otherwise it returns an abbreviated path (e.g. starting with ~
+if it is in the home folder)."
   (if (string-match-p
-       (expand-file-name dir) file)
+       (expand-file-name dir)
+       (expand-file-name file))
       (file-relative-name file dir)
     (abbreviate-file-name file)))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -93,10 +93,6 @@ affect a named session that you may happen to be visiting."
         ;; then kill it
         (kill-buffer)))))
 
-(defun mindstream--infer-major-mode-for-template (session-file)
-  "Infer the starting major mode for the TEMPLATE."
-    (mindstream--infer-major-mode session-file))
-
 (defun mindstream--full-filename-to-alist (filename)
   "Return cons cell of \(template . FILENAME\).
 FILENAME is assumed to be an absolute file name of a directory,
@@ -123,10 +119,6 @@ For example:
   "Start a new anonymous session using a specific TEMPLATE.
 
 This also begins a new session."
-  ;; end the current anonymous session for the
-  ;; desired major mode
-  (mindstream--end-anonymous-session
-   (mindstream--infer-major-mode-for-template session-file))
   ;; start a new session (sessions always start anonymous)
   (let ((buf (mindstream-start-anonymous-session template)))
     ;; (ab initio) iterate

--- a/mindstream.el
+++ b/mindstream.el
@@ -284,7 +284,7 @@ DIR is the directory containing the session.  If FILE is specified, it
 will be opened upon loading the session.  Otherwise, follow the default
 protocol for selecting a file, including, if necessary, prompting for
 the file to be opened."
-  (interactive (list ;; TODO: use completing-read-session
+  (interactive (list
                 (mindstream--completing-read-session)))
   (let ((file (or file
                   (mindstream--starting-file-for-session dir))))
@@ -303,7 +303,12 @@ the file to be opened."
   (let* ((dirs-alist (mapcar
                       (lambda (d)
                         (cons d (mindstream--session-file-name-expand d)))
-                      mindstream-session-history))
+                      (seq-uniq
+                       (append mindstream-session-history
+                               (mindstream--directory-files mindstream-save-session-path))
+                       (lambda (a b)
+                         (equal (string-trim-right a "/")
+                                (string-trim-right b "/"))))))
          (dir-key (completing-read "Which session? " dirs-alist nil t nil
                                    'mindstream-session-history))
          (dir (cdr (assoc-string dir-key dirs-alist))))

--- a/mindstream.el
+++ b/mindstream.el
@@ -304,8 +304,16 @@ the file to be opened."
                       (lambda (d)
                         (cons d (mindstream--session-file-name-expand d)))
                       (seq-uniq
-                       (append mindstream-session-history
-                               (mindstream--directory-files mindstream-save-session-path))
+                       ;; deduplicate candidates
+                       (seq-filter
+                        ;; exclude anonymous sessions
+                        (lambda (f)
+                          (not (string-match-p (abbreviate-file-name
+                                                (expand-file-name mindstream-path))
+                                               f)))
+                        (append mindstream-session-history
+                                (mindstream--directory-files mindstream-save-session-path)))
+                       ;; trim any trailing slashes for comparison
                        (lambda (a b)
                          (equal (string-trim-right a "/")
                                 (string-trim-right b "/"))))))

--- a/mindstream.el
+++ b/mindstream.el
@@ -296,8 +296,8 @@ you would typically want to specify a new, non-existent folder."
     (if named
         (mindstream-load-session dest-dir file)
       (mindstream-load-session
-       (mindstream--joindirs dest-dir
-                             original-session-name)
+       (mindstream--build-path dest-dir
+                               original-session-name)
        file))))
 
 (defun mindstream-load-session (&optional file)


### PR DESCRIPTION
### Summary of Changes

Build on #19 to streamline completion with history for:

- template selection
- starting file selection

... when starting new sessions and loading old sessions.

**Remaining work**:

- [ ] If `mindstream-save-session-path` has subdirectories, we cannot navigate into them as part of session selection by hitting Tab (it treats the entire folder as a session and then prompts for a file)
- [ ] We cannot navigate to paths manually in load-session

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
