### PR TITLE
Persistent and multiple anonymous sessions

### DIFF
--- a/doc/mindstream.scrbl
+++ b/doc/mindstream.scrbl
@@ -52,7 +52,7 @@ To add a new template, visit @code{mindstream-template-path} (default: @code{"~/
 
 @subsection{Saving Sessions}
 
-You can also save scratch sessions that you'd like to keep by using @code{mindstream-save-session} (default binding: @keybinding{C-c , C-s}). This simply clones the session's Git repo to a more permanent and familiar path that you indicate (as opposed to the anonymous session path which is assumed to be temporary and defaults to @code{~/.emacs.d/mindstream/anon}), thus preserving the entire session history, allowing it to be navigated and even resumed at any time in the future.
+You can also save scratch sessions that you'd like to keep by using @code{mindstream-save-session} (default binding: @keybinding{C-c , C-s}). This simply clones the session's Git repo to a more permanent and familiar path that you indicate (as opposed to the anonymous session path which is assumed to be ephemeral and defaults to @code{~/mindstream/anon}), thus preserving the entire session history, allowing it to be navigated and even resumed at any time in the future.
 
 @subsection{Entering Sessions Even More Quickly}
 
@@ -157,13 +157,11 @@ This tip is not about Mindstream specifically but more about a good workflow to 
 
 Mindstream sessions can have @emph{a lot} of commits, and they ensure that you never need to name your document at different stages of development out of fear that you'll lose important work. But if you happen to be writing a book, say, you might like to mark specific points as being significant in some way, so that if you ever have to search through earlier versions of your work, you'll know where to look. Traditionally, you might rename your file something like @code{draft_first_revision_final.tex}. From Mindstream's perspective, this a confusion of space and time. We seek to capture a moment in time, but we use a distinct place in space (a new file) for this purpose. In Mindstream, it'd be better to use a standard feature of Git, @emph{tagging}, to achieve the same result. That is, when you arrive at a version you think is significant, simply tag the current commit (using a Git client of your choice, such as Magit) with a name and a message. It's a much more useful way to do it than @code{draft_final_final_....tex}! For example, it allows you to very quickly switch to different "good" versions (e.g. in Magit, @keybinding{bb} and then select a tag in the completion menu) that you could show to editors for proofreading.
 
-@subsection{Choosing a Session Path}
+@subsection{Choosing an Archive Path}
 
-Mindstream stores anonymous sessions under a randomly generated folder name. This allows you to enter a freewriting session without worrying about the messy details of naming and storing files. As a result, it's likely that you will work on dozens, hundreds, or thousands of such sessions over time, of which you will keep only a small minority as saved, named sessions. For the anonymous sessions you don't save, you may prefer to just delete them from time to time rather than have them accumulate. Many operating systems provide standard ways to do this kind of thing -- @emph{temp folders}, usually named @code{tmp} -- which are occasionally cleared automatically by the operating system, without requiring you to manage this. If your operating system provides a good option here, you may prefer to use it.
+Mindstream stores anonymous sessions under a randomly generated folder name under @variable{mindstream-path} (default: @code{~/mindstream/anon}). Sessions that you don't save will be @emph{archived} instead, which moves them to @variable{mindstream-archive-path} (default: @code{~/mindstream/saved}).
 
-@subsubsection{Your Emacs Folder}
-
-By default, anonymous sessions are placed in the @code{mindstream/anon} folder in your Emacs directory (e.g. @code{.emacs.d}). This is a safe default, as it is entirely under your control and you can clear this folder (if you wish to) or leave it to its own devices, as you see fit. If you retain this default behavior, you may want to add @code{mindstream/anon} to your @code{.gitignore} for your Emacs directory (assuming you keep your Emacs config versioned and publicly hosted, as many Emacs users do), so that these freewrite sessions aren't publicly visible.
+As it's likely that you will work on dozens, hundreds, or thousands of anonymous sessions over time, of which you will only save a small minority. For the remaining, archived, sessions, you may prefer to just delete these from time to time rather than have them accumulate. Many operating systems provide standard ways to do this kind of thing -- @emph{temp folders}, usually named @code{tmp} -- which are occasionally cleared automatically by the operating system, without requiring you to manage this. If your operating system provides a good option here, you may prefer to use it.
 
 @subsubsection{@code{/var/tmp}}
 
@@ -189,7 +187,7 @@ Another option that's similar to this one but more predictable is to define a ne
            "tmp/mindstream"))
 }
 
-Remember that the path we are configuring here is for @emph{anonymous sessions} only. If you decide to keep a session around and save it via @code{mindstream-save} (default binding: @keybinding{C-c , C-s}), it would be saved to @code{mindstream-save-session-path} which defaults to your home folder. You can customize this as well, of course:
+Remember that the path we are configuring here is for @emph{anonymous sessions} only. If you decide to keep a session around and save it via @code{mindstream-save} (default binding: @keybinding{C-c , C-s}), it would be saved to @code{mindstream-save-session-path} which defaults to @code{~/mindstream/saved}. You can customize this as well, of course:
 
 @codeblock{
   :custom

--- a/doc/mindstream.scrbl
+++ b/doc/mindstream.scrbl
@@ -3,6 +3,12 @@
 @(define-syntax-rule (keybinding arg)
    (bold (code arg)))
 
+@(define-syntax-rule (variable arg)
+   (bold (code arg)))
+
+@(define-syntax-rule (function arg)
+   (bold (code arg)))
+
 @title{mindstream}
 
 If you've ever created throwaway files named @code{1.txt} or @code{blah.py} or @code{test3.rkt} to quickly write down some thoughts, try out a new idea, or prototype a new software tool, then you've already experienced the inconvenience of having to first come up with a name for these throwaway files, a small obstruction that is sometimes enough to snuff out that momentary creative spark that might have become a worthy conflagration. You've also probably experienced the cost of not creating such files, when just as the quick and anonymous freewriting session started to grow into something you'd want to keep around, an application error or computer crash caused you to lose it all and be more discouraged than when you began.
@@ -13,7 +19,7 @@ Mindstream removes the barriers so that you can start writing immediately, and s
 
 Mindstream is a lightweight tool that leaves most of the heavy lifting to other packages (including major modes) and technologies (such as Git). It simply uses these together to augment your existing workflows to fill an unmet need.
 
-Every mindstream session begins from a template (an ordinary folder) that you provide, and evolves through the stages of your creative process. The session itself is stored as an ordinary folder in a unique Git repository at a temporary location on disk. This repository is versioned by commits representing your writing process bounded at natural points -- by default, the points at which your buffer is saved (whether explicitly by you or implicitly on running a command like @hyperlink["https://racket-mode.com/#racket_002drun"]{racket-run}). In this way, Mindstream saves you the trouble of coming up with extraneous names (e.g. @code{draft1.tex}, @code{draft2.tex}, ..., @code{draft_final2.tex}, ...) and allows you to focus on the task at hand. You can save and load these sessions, too, and pick up right where you left off, allowing quick freewriting sessions to organically grow into robust creative works.
+Every mindstream session begins from a template (an ordinary folder) that you provide, and evolves through the stages of your creative process. The session itself is stored as an ordinary folder in a unique Git repository at a temporary location on disk. This repository is versioned by commits representing your writing process bounded at natural points -- by default, the points at which your buffer is saved (whether explicitly by you or implicitly on running a command like @hyperlink["https://racket-mode.com/#racket_002drun"]{@function{racket-run}}). In this way, Mindstream saves you the trouble of coming up with extraneous names (e.g. @code{draft1.tex}, @code{draft2.tex}, ..., @code{draft_final2.tex}, ...) and allows you to focus on the task at hand. You can save and load these sessions, too, and pick up right where you left off, allowing quick freewriting sessions to organically grow into robust creative works.
 
 Typical uses of this package are for early stages of prototyping in a software project, or for exploratory programming to understand a new idea, tool, or technology. It's also great for just taking quick notes or freewriting blog posts or content in authoring settings in general.
 
@@ -36,7 +42,7 @@ Place the following config somewhere in your @code{.emacs.d}:
 @section{Usage}
 
 @itemlist[#:style 'ordered
-    @item{Run @code{mindstream-new} (default: @keybinding{C-c , n}) to start a session.}
+    @item{Run @function{mindstream-new} (default: @keybinding{C-c , n}) to start a session.}
     @item{Write!}
 ]
 
@@ -48,15 +54,15 @@ You may notice that there is only one template available to use for your first s
 
 Mindstream doesn't include any templates out of the box, so you'll probably want to create some for standard sessions you are likely to need, for instance, for programming in your favorite language (perhaps @hyperlink["https://racket-lang.org/"]{Racket}?), or just freewriting some text for your next great novel, following in the keystrokes of Emacs octopuses like Neal Stephenson.
 
-To add a new template, visit @code{mindstream-template-path} (default: @code{"~/.mindstream/templates/"}) in your filemanager of choice (e.g. Emacs's @code{dired}, or just a command line), and create a folder there with the name of your template (e.g. @code{racket}). The folder should contain an ordinary file (or multiple files) with the appropriate extension (e.g. @code{.rkt} -- it could be anything at all that you typically use Emacs to edit). This template will now be available as an option in @code{mindstream-new}.
+To add a new template, visit @variable{mindstream-template-path} (default: @code{"~/.emacs.d/mindstream/templates/"}) in your filemanager of choice (e.g. Emacs's @code{dired}, or just a command line), and create a folder there with the name of your template (e.g. @code{racket}). The folder should contain an ordinary file (or multiple files) with the appropriate extension (e.g. @code{.rkt} -- it could be anything at all that you typically use Emacs to edit). This template will now be available as an option in @function{mindstream-new}.
 
 @subsection{Saving Sessions}
 
-You can also save scratch sessions that you'd like to keep by using @code{mindstream-save-session} (default binding: @keybinding{C-c , C-s}). This simply clones the session's Git repo to a more permanent and familiar path that you indicate (as opposed to the anonymous session path which is assumed to be ephemeral and defaults to @code{~/mindstream/anon}), thus preserving the entire session history, allowing it to be navigated and even resumed at any time in the future.
+You can also save scratch sessions that you'd like to keep by using @function{mindstream-save-session} (default binding: @keybinding{C-c , C-s}). This simply clones the session's Git repo to a more permanent and familiar path that you indicate (as opposed to the anonymous session path which is assumed to be ephemeral and defaults to @code{~/mindstream/anon}), thus preserving the entire session history, allowing it to be navigated and even resumed at any time in the future.
 
 @subsection{Entering Sessions Even More Quickly}
 
-@code{mindstream-enter-anonymous-session} (default: @keybinding{C-c , b}) will take you immediately to a new anonymous session for the current major mode, without asking you any questions. If an anonymous session already exists, it will take you there rather than create a new one. In creating a new session, it will use the first template it finds that is recognizable to your current major mode.
+@function{mindstream-enter-anonymous-session} (default: @keybinding{C-c , b}) will take you immediately to a new anonymous session for the current major mode, without asking you any questions. If an anonymous session already exists, it will take you there rather than create a new one. In creating a new session, it will use the first template it finds that is recognizable to your current major mode.
 
 If you've got more than one template for a particular major mode, you may want to indicate which one is preferred rather than leave it to chance or accidents of alphabetical order. You can do this by associating each major mode with the name of the preferred template. For example:
 
@@ -66,7 +72,7 @@ If you've got more than one template for a particular major mode, you may want t
   (mindstream-preferred-template '(racket-mode "racket.rkt"))
 }
 
-This customization is only relevant when using @code{mindstream-enter-anonymous-session}, as you would select the template yourself when using @code{mindstream-new}.
+This customization is only relevant when using @function{mindstream-enter-anonymous-session}, as you would select the template yourself when using @function{mindstream-new}.
 
 See "Design" below to learn more about anonymous sessions.
 
@@ -104,7 +110,7 @@ Mindstream sessions are just ordinary Git repositories. If you wanted to, you co
 
 @subsection{Explore}
 
-Try @keybinding{M-x mindstream- ...} to see all the available interactive commands. These are also included as keybindings in a minor mode, @code{mindstream-mode}, which allows you to enter a Mindstream session from anywhere, and contains useful commands for active sessions like saving the session, "going live," and so on.
+Try @keybinding{M-x mindstream- ...} to see all the available interactive commands. These are also included as keybindings in a minor mode, @variable{mindstream-mode}, which allows you to enter a Mindstream session from anywhere, and contains useful commands for active sessions like saving the session, "going live," and so on.
 
 Mindstream commands are bound by default under the prefix @keybinding{C-c , ...}. You can view all Mindstream commands by using Emacs's @keybinding{C-h} introspection with this prefix, as in @keybinding{C-c , C-h}.
 
@@ -114,7 +120,7 @@ As each Mindstream session uses a specific major mode, it inherits all of the cu
 
 For instance, one common use of Mindstream is as a scratch buffer with Racket Mode. Racket Mode users sometimes @hyperlink["https://racket-mode.com/#Edit-buffers-and-REPL-buffers"]{like to have a dedicated REPL} to view the output of code they write in a particular buffer, instead of reusing a REPL shared across all buffers. If you're a Racket Mode user, whatever customization you've chosen here would apply to Mindstream session buffers just as they would any buffer, and your Racket Mode sessions may or may not have a dedicated REPL depending on how you've customized this for Racket Mode generally.
 
-But if you happen to want to use a different customization for Mindstream session buffers in a certain major mode than you prefer generally for that major mode, advising the @code{mindstream-new} function could be one way to achieve that. For instance, for the customization we have been talking about:
+But if you happen to want to use a different customization for Mindstream session buffers in a certain major mode than you prefer generally for that major mode, advising the @function{mindstream-new} function could be one way to achieve that. For instance, for the customization we have been talking about:
 
 @codeblock{
   (advice-add 'mindstream-new
@@ -129,7 +135,7 @@ Mindstream structures your workflow in sessions, which are version-controlled fi
 
 @itemlist[#:style 'ordered
   @item{There is only one anonymous scratch session active at any time, per major mode.}
-  @item{Saving an anonymous session turns it into a named session, and there is no active anonymous session at that point. Named sessions work the same as anonymous sessions aside from having a name and being in a permanent location on disk. A new anonymous session could be started at any time via @code{mindstream-new}.}
+  @item{Saving an anonymous session turns it into a named session, and there is no active anonymous session at that point. Named sessions work the same as anonymous sessions aside from having a name and being in a permanent location on disk. A new anonymous session could be started at any time via @function{mindstream-new}.}
   @item{New sessions always begin as anonymous.}
   @item{Named sessions may be loaded without interfering with the active anonymous session.}
   @item{Any number of named sessions could be active at the same time. Sessions are self-contained and independent.}
@@ -187,7 +193,7 @@ Another option that's similar to this one but more predictable is to define a ne
            "tmp/mindstream"))
 }
 
-Remember that the path we are configuring here is for @emph{anonymous sessions} only. If you decide to keep a session around and save it via @code{mindstream-save} (default binding: @keybinding{C-c , C-s}), it would be saved to @code{mindstream-save-session-path} which defaults to @code{~/mindstream/saved}. You can customize this as well, of course:
+Remember that the path we are configuring here is for @emph{anonymous sessions} only. If you decide to keep a session around and save it via @function{mindstream-save} (default binding: @keybinding{C-c , C-s}), it would be saved to @variable{mindstream-save-session-path} which defaults to @code{~/mindstream/saved}. You can customize this as well, of course:
 
 @codeblock{
   :custom

--- a/mindstream-backend.el
+++ b/mindstream-backend.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'mindstream-custom)
+(require 'magit-git)
 
 (defun mindstream--execute-shell-command (command &optional directory)
   "Execute shell COMMAND at DIRECTORY.
@@ -72,6 +73,15 @@ and arguments that are to be supplied to the command."
   "Add FILE to the Git index."
   (mindstream--execute-shell-command
    (list "git" "add" file)))
+
+(defun mindstream-backend-root (&optional buffer)
+  "Get the root folder of the VCS for BUFFER."
+  (let ((buffer (or buffer (current-buffer))))
+    (with-current-buffer buffer
+      ;; (vc-root-dir) returns nil in some cases,
+      ;; e.g. for an anonymous text session,
+      ;; but magit-toplevel seems to work.
+      (magit-toplevel))))
 
 (provide 'mindstream-backend)
 ;;; mindstream-backend.el ends here

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -111,6 +111,11 @@ for the major mode so that it would be selected."
   :type 'string
   :group 'mindstream)
 
+(defcustom mindstream-persist nil
+  "Whether anonymous sessions should persist across Emacs restarts until archived."
+  :type 'boolean
+  :group 'mindstream)
+
 (defcustom mindstream-add-everything t
   "Whether to add all files to the index before commiting on each iteration."
   :type 'boolean

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -44,8 +44,8 @@
   :group 'Editing)
 
 (defcustom mindstream-path
-  ;; platform-independent ~/.emacs.d/mindstream/anon
-  (mindstream--build-path user-emacs-directory
+  ;; platform-independent ~/mindstream/anon
+  (mindstream--build-path mindstream--user-home-directory
                           "mindstream"
                           "anon")
   "Directory where anonymous mindstream sessions will be stored."
@@ -62,8 +62,10 @@
   :group 'mindstream)
 
 (defcustom mindstream-save-session-path
+  ;; platform-independent ~/mindstream/saved
   (mindstream--build-path mindstream--user-home-directory
-                          "mindstream")
+                          "mindstream"
+                          "saved")
   "Default directory path for saving mindstream sessions."
   :type 'string
   :group 'mindstream)

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -68,6 +68,15 @@
   :type 'string
   :group 'mindstream)
 
+(defcustom mindstream-archive-path
+  ;; platform-independent ~/.emacs.d/mindstream/archive
+  (mindstream--build-path user-emacs-directory
+                          "mindstream"
+                          "archive")
+  "Directory where archived anonymous mindstream sessions will be stored."
+  :type 'string
+  :group 'mindstream)
+
 (defcustom mindstream-triggers (list #'save-buffer)
   "Functions that, when called, should implicitly iterate the mindstream buffer."
   :type 'list

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -71,8 +71,8 @@
   :group 'mindstream)
 
 (defcustom mindstream-archive-path
-  ;; platform-independent ~/.emacs.d/mindstream/archive
-  (mindstream--build-path user-emacs-directory
+  ;; platform-independent ~/mindstream/archive
+  (mindstream--build-path mindstream--user-home-directory
                           "mindstream"
                           "archive")
   "Directory where archived anonymous mindstream sessions will be stored."

--- a/mindstream-custom.el
+++ b/mindstream-custom.el
@@ -116,6 +116,15 @@ for the major mode so that it would be selected."
   :type 'boolean
   :group 'mindstream)
 
+(defcustom mindstream-unique t
+  "Whether there should be a unique anonymous session per template.
+
+If true, then starting a new anonymous session always archives any
+existing ones.  If nil, then any number of anonymous sessions may be
+active for the template at any given time."
+  :type 'boolean
+  :group 'mindstream)
+
 (defcustom mindstream-add-everything t
   "Whether to add all files to the index before commiting on each iteration."
   :type 'boolean

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -297,10 +297,10 @@ buffer is used."
   (let ((buffer-name (mindstream-anonymous-buffer-name major-mode-to-use)))
     (get-buffer buffer-name)))
 
-(defun mindstream-anonymous-session-buffer-p ()
-  "Predicate to check if the current buffer is the anonymous scratch buffer."
-  ;; TODO: this is fairly weak
-  (string-match-p mindstream-anonymous-buffer-prefix (buffer-name)))
+(defun mindstream-anonymous-session-p ()
+  "Predicate to check if the current buffer is part of an anonymous session."
+  (mindstream--file-in-tree-p (buffer-file-name)
+                              mindstream-path))
 
 (provide 'mindstream-session)
 ;;; mindstream-session.el ends here

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -144,8 +144,7 @@ buffers at the SESSION path."
 This creates an appropriate base path on disk for the TEMPLATE if it
 isn't already present."
   (let* ((session-name (mindstream--unique-name))
-         (base-path (mindstream--build-path mindstream-path
-                                            (mindstream--template-name template))))
+         (base-path (mindstream--anonymous-path template)))
     (mindstream--ensure-path base-path)
     (mindstream--build-path base-path
                             session-name)))
@@ -154,7 +153,7 @@ isn't already present."
   "Path to TEMPLATE.
 
 TEMPLATE is expected to be a simple name corresponding to the name of
-a folder at `mindstream-template-path'. If it isn't provided, use the
+a folder at `mindstream-template-path'.  If it isn't provided, use the
 default template."
   (mindstream--build-path mindstream-template-path
                           (or template mindstream-default-template)))
@@ -163,7 +162,7 @@ default template."
   "Path to anonymous sessions using TEMPLATE.
 
 TEMPLATE is expected to be a simple name corresponding to the name of
-a folder at `mindstream-template-path'. If it isn't provided, use the
+a folder at `mindstream-template-path'.  If it isn't provided, use the
 default template."
   (mindstream--build-path mindstream-path
                           (or template mindstream-default-template)))
@@ -172,7 +171,7 @@ default template."
   "Path to archived sessions using TEMPLATE.
 
 TEMPLATE is expected to be a simple name corresponding to the name of
-a folder at `mindstream-template-path'. If it isn't provided, use the
+a folder at `mindstream-template-path'.  If it isn't provided, use the
 default template."
   (mindstream--build-path mindstream-archive-path
                           (or template mindstream-default-template)))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -130,33 +130,6 @@ buffers at the SESSION path."
   (let ((path (or path default-directory)))
     (member path mindstream-active-sessions)))
 
-(defun mindstream-start-anonymous-session (&optional template)
-  "Start a new anonymous session.
-
-This creates a new directory and Git repository for the new session
-after copying over the contents of TEMPLATE if one is specified.
-Otherwise, it uses the configured default template.
-
-New sessions always start anonymous."
-  (let* ((template (mindstream--template-path
-                    (or template
-                        mindstream-default-template)))
-         (filename (mindstream--starting-file-for-session template))
-         (major-mode-to-use (mindstream--infer-major-mode filename))
-         (path (mindstream--generate-anonymous-session-path template)))
-    (unless (file-directory-p path)
-      (copy-directory template path)
-      (mindstream-backend-initialize path)
-      ;; TODO: archive instead of end,
-      ;; conditioned on `mindstream-unique'
-      ;; (mindstream--end-anonymous-session major-mode-to-use)
-      (find-file
-       (expand-file-name filename
-                         path))
-      (mindstream--initialize-buffer)
-      (mindstream-begin-session)
-      (current-buffer))))
-
 (defun mindstream--iterate ()
   "Commit the current state as part of iteration."
   ;; always add the current file (where mindstream-session-mode

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -154,7 +154,6 @@ New sessions always start anonymous."
        (expand-file-name filename
                          path))
       (mindstream--initialize-buffer)
-      (rename-buffer (mindstream-anonymous-buffer-name))
       (mindstream-begin-session)
       (current-buffer))))
 
@@ -287,14 +286,6 @@ buffer is used."
         ;; on older versions of Emacs
         mode-name
       (car mode-name))))
-
-(defun mindstream-anonymous-buffer-name (&optional major-mode-to-use)
-  "Name of the anonymous session buffer for MAJOR-MODE-TO-USE."
-  (concat "*"
-          mindstream-anonymous-buffer-prefix
-          " - "
-          (mindstream--mode-name major-mode-to-use)
-          "*"))
 
 (defun mindstream-anonymous-session-p ()
   "Predicate to check if the current buffer is part of an anonymous session."

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -196,12 +196,32 @@ isn't already present."
     (mindstream--build-path base-path
                             session-name)))
 
-(defun mindstream--template-path (&optional name)
-  "Path to template NAME.
+(defun mindstream--template-path (&optional template)
+  "Path to TEMPLATE.
 
-If NAME isn't provided, use the default template."
+TEMPLATE is expected to be a simple name corresponding to the name of
+a folder at `mindstream-template-path'. If it isn't provided, use the
+default template."
   (mindstream--build-path mindstream-template-path
-                          (or name mindstream-default-template)))
+                          (or template mindstream-default-template)))
+
+(defun mindstream--anonymous-path (&optional template)
+  "Path to anonymous sessions using TEMPLATE.
+
+TEMPLATE is expected to be a simple name corresponding to the name of
+a folder at `mindstream-template-path'. If it isn't provided, use the
+default template."
+  (mindstream--build-path mindstream-path
+                          (or template mindstream-default-template)))
+
+(defun mindstream--archive-path (&optional template)
+  "Path to archived sessions using TEMPLATE.
+
+TEMPLATE is expected to be a simple name corresponding to the name of
+a folder at `mindstream-template-path'. If it isn't provided, use the
+default template."
+  (mindstream--build-path mindstream-archive-path
+                          (or template mindstream-default-template)))
 
 (defun mindstream--template-name (path)
   "Name of template at PATH."

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -98,23 +98,6 @@ filename relative to DIR rather than an absolute path."
                                                        mindstream-save-session-path))
   (message "Session started at %s." default-directory))
 
-(defun mindstream--end-anonymous-session (&optional major-mode-to-use)
-  "End the current anonymous session.
-
-This ends the current anonymous session for MAJOR-MODE-TO-USE and does not
-affect a named session that you may happen to be visiting."
-  ;; TODO: may want to also kill any other open buffers at the same base path
-  (let ((buf (mindstream--get-anonymous-session-buffer major-mode-to-use)))
-    (when buf
-      (with-current-buffer buf
-        ;; first write the existing scratch buffer
-        ;; if there are unsaved changes
-        (mindstream--iterate)
-        ;; end the anonymous session
-        (mindstream-end-session)
-        ;; then kill it
-        (kill-buffer)))))
-
 (defun mindstream-end-session (&optional session)
   "End SESSION.
 
@@ -133,7 +116,6 @@ buffers at the SESSION path."
                                                           session))))))
   (let ((session (or session (mindstream--current-session))))
     ;; session can be nil if called non-interactively
-    ;; as in `mindstream--end-anonymous-session'
     (setq mindstream-active-sessions
           (remove session mindstream-active-sessions))
     (message "Session %s ended." session)))
@@ -167,7 +149,7 @@ New sessions always start anonymous."
       (mindstream-backend-initialize path)
       ;; TODO: archive instead of end,
       ;; conditioned on `mindstream-unique'
-      (mindstream--end-anonymous-session major-mode-to-use)
+      ;; (mindstream--end-anonymous-session major-mode-to-use)
       (find-file
        (expand-file-name filename
                          path))
@@ -313,11 +295,6 @@ buffer is used."
           " - "
           (mindstream--mode-name major-mode-to-use)
           "*"))
-
-(defun mindstream--get-anonymous-session-buffer (&optional major-mode-to-use)
-  "Get the active anonymous session buffer for MAJOR-MODE-TO-USE, if it exists."
-  (let ((buffer-name (mindstream-anonymous-buffer-name major-mode-to-use)))
-    (get-buffer buffer-name)))
 
 (defun mindstream-anonymous-session-p ()
   "Predicate to check if the current buffer is part of an anonymous session."

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -135,6 +135,8 @@ New sessions always start anonymous."
     (unless (file-directory-p path)
       (copy-directory template path)
       (mindstream-backend-initialize path)
+      ;; TODO: archive instead of end,
+      ;; conditioned on `mindstream-unique'
       (mindstream--end-anonymous-session major-mode-to-use)
       (find-file
        (expand-file-name filename

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -156,8 +156,9 @@ after copying over the contents of TEMPLATE if one is specified.
 Otherwise, it uses the configured default template.
 
 New sessions always start anonymous."
-  (let* ((template (or template
-                       (mindstream--template-path mindstream-default-template)))
+  (let* ((template (mindstream--template-path
+                    (or template
+                        (mindstream--template-path mindstream-default-template))))
          (filename (mindstream--starting-file-for-session template))
          (major-mode-to-use (mindstream--infer-major-mode filename))
          (path (mindstream--generate-anonymous-session-path template)))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -211,9 +211,10 @@ If NAME isn't provided, use the default template."
   (unless (file-directory-p path)
     (mkdir path t)))
 
-(defun mindstream--ensure-anonymous-path ()
-  "Ensure that the anonymous session path exists."
-  (mindstream--ensure-path mindstream-path))
+(defun mindstream--ensure-paths ()
+  "Ensure that paths that mindstream needs to function exist."
+  (mindstream--ensure-path mindstream-path)
+  (mindstream--ensure-path mindstream-archive-path))
 
 (defun mindstream--ensure-templates-exist ()
   "Ensure that the templates directory exists and contains the default template."

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -158,7 +158,7 @@ Otherwise, it uses the configured default template.
 New sessions always start anonymous."
   (let* ((template (mindstream--template-path
                     (or template
-                        (mindstream--template-path mindstream-default-template))))
+                        mindstream-default-template)))
          (filename (mindstream--starting-file-for-session template))
          (major-mode-to-use (mindstream--infer-major-mode filename))
          (path (mindstream--generate-anonymous-session-path template)))

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -233,32 +233,6 @@ Search the templates folder for a template recognizable to MAJOR-MODE-TO-USE."
     (or template-name
         (mindstream--find-template-for-mode major-mode-to-use))))
 
-(defun mindstream--infer-major-mode (filename)
-  "Infer a major mode to use.
-
-Given a FILENAME, this infers the appropriate major mode based on the
-file extension by consulting Emacs."
-  (let ((extension (concat "." (file-name-extension filename))))
-    (let ((mode (mindstream--major-mode-for-file-extension extension)))
-      (or mode
-          (error "No major modes recognize the template extension '%s'!" extension)))))
-
-(defun mindstream--mode-name (major-mode-to-use)
-  "Human readable name of MAJOR-MODE-TO-USE.
-
-If MAJOR-MODE-TO-USE is not provided, the major mode of the current
-buffer is used."
-  (if major-mode-to-use
-      (string-trim-right
-       (capitalize
-        (substring
-         (symbol-name major-mode-to-use)
-         0 -5)))
-    (if (stringp mode-name)
-        ;; on older versions of Emacs
-        mode-name
-      (car mode-name))))
-
 (defun mindstream-anonymous-session-p ()
   "Predicate to check if the current buffer is part of an anonymous session."
   (mindstream--file-in-tree-p (buffer-file-name)

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -157,7 +157,9 @@ If any buffers have been modified, they will be saved first."
 (defun mindstream--file-in-tree-p (file dir)
   "Is FILE part of the directory tree starting at DIR?"
   ;; Source: `dired-in-this-tree-p'
-  (let (case-fold-search)
+  (let (case-fold-search
+        (file (expand-file-name file))
+        (dir (expand-file-name dir)))
     (string-match-p (concat "^" (regexp-quote dir)) file)))
 
 (defun mindstream--session-name ()

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -146,7 +146,7 @@ a file in FROM-DIR to refer to TO-DIR."
                   to-dir))
          (from-pat from-dir)
          (to-pat (if (file-directory-p to-dir)
-                     (concat to-dir
+                     (concat (file-name-as-directory to-dir)
                              (file-name-as-directory
                               (mindstream--directory-name
                                from-dir)))

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -122,6 +122,19 @@ and mutate that variable in ACTION."
         (funcall action))
       (setq blist (cdr blist)))))
 
+(defun mindstream--find-buffer (predicate)
+  "Find the first buffer that returns true for PREDICATE.
+
+PREDICATE must take no arguments. The matching buffer is returned, or
+nil if there is no match."
+  (let ((blist (buffer-list)))
+    (catch 'break
+      (while blist
+        (with-current-buffer (car blist)
+          (when (funcall predicate)
+            (throw 'break (current-buffer))))
+        (setq blist (cdr blist))))))
+
 (defun mindstream--move-dir (from-dir to-dir)
   "Move folder FROM-DIR to TO-DIR.
 

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -117,7 +117,7 @@ This only operates on buffers that are visiting files, and not
 non-file buffers, since all buffers of interest for our purposes
 correspond to files on disk.
 
-ACTION must take no arguments and should return nothing. If a return
+ACTION must take no arguments and should return nothing.  If a return
 value is desired, then use a closure with a mutable lexical variable,
 and mutate that variable in ACTION."
   (let ((blist (buffer-list)))
@@ -130,7 +130,7 @@ and mutate that variable in ACTION."
 (defun mindstream--find-buffer (predicate)
   "Find the first buffer that returns true for PREDICATE.
 
-PREDICATE must take no arguments. The matching buffer is returned, or
+PREDICATE must take no arguments.  The matching buffer is returned, or
 nil if there is no match."
   (let ((blist (buffer-list)))
     (catch 'break
@@ -211,20 +211,13 @@ This is simply the name of the containing folder."
    "^.*/"))
 
 (defun mindstream--session-dir (&optional buffer)
-  "The repo base path containing FILE."
-  ;; TODO: generalize to derive base repo path
-  ;; in case the file is in a nested path
-  (let ((buffer (or buffer (current-buffer))))
-    (with-current-buffer buffer
-      ;; (vc-root-dir) returns nil in some cases,
-      ;; e.g. for an anonymous text session,
-      ;; but magit-toplevel seems to work.
-      (magit-toplevel))))
+  "The repo base path containing BUFFER."
+  (mindstream-backend-root buffer))
 
 (defun mindstream--get-containing-dir (file)
   "Get the name of the directory containing FILE.
 
-FILE could be a file or a directory. Only the name of the containing
+FILE could be a file or a directory.  Only the name of the containing
 directory is returned, rather than its full path."
   (let ((file (if (directory-name-p file)
                   (directory-file-name file)

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -93,6 +93,40 @@ platform-appropriate way.
     (file-name-directory
      path))))
 
+(defun mindstream--move-dir (from-dir to-dir)
+  "Move folder FROM-DIR to TO-DIR.
+
+This also updates the visited file names of all open buffers visiting
+a file in FROM-DIR to refer to TO-DIR."
+  ;; Based on `dired-rename-file' and `dired-rename-subdir'
+  (rename-file from-dir to-dir nil)
+  (setq from-dir (file-name-as-directory from-dir)
+	    to-dir (file-name-as-directory to-dir))
+  ;; Update visited file name of all affected buffers
+  (let ((expanded-from-dir (expand-file-name from-dir))
+	    (blist (buffer-list)))
+    (while blist
+      (with-current-buffer (car blist)
+	    (if (and buffer-file-name
+		         (mindstream--file-in-tree-p buffer-file-name
+                                             expanded-from-dir))
+	        (let ((modflag (buffer-modified-p))
+                  ;; TODO: this is not a robust way to update
+                  ;; the visited file path, since
+                  ;; /a/b/a/c.txt -> /a/b/b/c.txt
+                  ;; would rewrite to /b/b/b/c.txt
+                  ;; but it works in "most" cases where
+                  ;; the renamed folder isn't a trailing
+                  ;; match on a containing folder name
+                  ;; Improve this.
+                  (to-file (replace-regexp-in-string
+			                (regexp-quote from-dir)
+			                to-dir
+			                buffer-file-name)))
+	          (set-visited-file-name to-file)
+	          (set-buffer-modified-p modflag))))
+      (setq blist (cdr blist)))))
+
 (defun mindstream--file-in-tree-p (file dir)
   "Is FILE part of the directory tree starting at DIR?"
   ;; Source: `dired-in-this-tree-p'

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -67,14 +67,21 @@ platform-appropriate way.
            (expand-file-name (car dirs) root)
            (cdr dirs))))
 
-(defun mindstream--directory-files (dir)
-  "List files in DIR that aren't hidden or special."
+(defun mindstream--directory-files (dir &optional full)
+  "List files in DIR that aren't hidden or special.
+
+Return FULL, absolute paths, or relative paths."
   ;; TODO: exclude files that aren't versioned by Git
-  (seq-filter (lambda (x)
-                ;; e.g. .gitignore
-                (not (string-match-p "^\\." x)))
-              (directory-files dir
-                               nil)))
+  (let ((files (seq-filter (lambda (x)
+                             ;; e.g. .gitignore
+                             (not (string-match-p "^\\." x)))
+                           (directory-files dir
+                                            nil))))
+    (if full
+        (seq-map (lambda (d)
+                   (expand-file-name d dir))
+                 files)
+      files)))
 
 (defun mindstream--directory-files-recursively (dir)
   "List files in DIR that aren't hidden or special."

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -70,6 +70,8 @@ platform-appropriate way.
 (defun mindstream--directory-files (dir &optional full)
   "List files in DIR that aren't hidden or special.
 
+This includes subdirectories.
+
 Return FULL, absolute paths, or relative paths."
   ;; TODO: exclude files that aren't versioned by Git
   (let ((files (seq-filter (lambda (x)
@@ -82,6 +84,14 @@ Return FULL, absolute paths, or relative paths."
                    (expand-file-name d dir))
                  files)
       files)))
+
+(defun mindstream--directory-dirs (dir)
+  "List subdirectories in DIR."
+  (seq-filter (lambda (file)
+                (file-directory-p file))
+              (mindstream--directory-files dir
+                                           ;; always absolute for now
+                                           t)))
 
 (defun mindstream--directory-files-recursively (dir)
   "List files in DIR that aren't hidden or special."

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -150,7 +150,7 @@ a file in FROM-DIR to refer to TO-DIR."
                              (file-name-as-directory
                               (mindstream--directory-name
                                from-dir)))
-                   to-dir)))
+                   (file-name-as-directory to-dir))))
     (rename-file from-dir
                  (if (file-directory-p to-dir)
                      (file-name-as-directory to-dir)

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -210,11 +210,16 @@ This is simply the name of the containing folder."
     (file-name-directory (buffer-file-name)))
    "^.*/"))
 
-(defun mindstream--session-dir (file)
+(defun mindstream--session-dir (&optional buffer)
   "The repo base path containing FILE."
   ;; TODO: generalize to derive base repo path
   ;; in case the file is in a nested path
-  (file-name-directory file))
+  (let ((buffer (or buffer (current-buffer))))
+    (with-current-buffer buffer
+      ;; (vc-root-dir) returns nil in some cases,
+      ;; e.g. for an anonymous text session,
+      ;; but magit-toplevel seems to work.
+      (magit-toplevel))))
 
 (provide 'mindstream-util)
 ;;; mindstream-util.el ends here

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -120,16 +120,16 @@ a file in FROM-DIR to refer to TO-DIR."
     (let ((blist (buffer-list)))
       (while blist
         (with-current-buffer (car blist)
-	      (if (and buffer-file-name
-		           (mindstream--file-in-tree-p buffer-file-name
-                                               from-dir))
-	          (let ((modflag (buffer-modified-p))
-                    (to-file (replace-regexp-in-string
-                              (concat "^" (regexp-quote from-pat))
-			                  to-pat
-			                  buffer-file-name)))
-	            (set-visited-file-name to-file)
-	            (set-buffer-modified-p modflag))))
+          (when (and buffer-file-name
+		             (mindstream--file-in-tree-p buffer-file-name
+                                                 from-dir))
+	        (let ((modflag (buffer-modified-p))
+                  (to-file (replace-regexp-in-string
+                            (concat "^" (regexp-quote from-pat))
+			                to-pat
+			                buffer-file-name)))
+	          (set-visited-file-name to-file)
+	          (set-buffer-modified-p modflag))))
         (setq blist (cdr blist))))))
 
 (defun mindstream--file-in-tree-p (file dir)

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -42,16 +42,6 @@ This searches PATH recursively."
     (when files
       (car files))))
 
-(defun mindstream--major-mode-for-file-extension (extension)
-  "Appropriate major mode for the given file EXTENSION.
-
-This consults Emacs's `auto-mode-alist'."
-  (catch 'return
-    (dolist (assoc auto-mode-alist)
-      (pcase-let ((`(,ext . ,mode) assoc))
-        (when (string-match-p ext extension)
-          (throw 'return mode))))))
-
 ;; From: https://stackoverflow.com/a/13473856/323874
 (defun mindstream--build-path (root &rest dirs)
   "Joins a series of directories together, like Python's os.path.join.

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -93,5 +93,11 @@ platform-appropriate way.
     (file-name-directory
      path))))
 
+(defun mindstream--file-in-tree-p (file dir)
+  "Is FILE part of the directory tree starting at DIR?"
+  ;; Source: `dired-in-this-tree-p'
+  (let (case-fold-search)
+    (string-match-p (concat "^" (regexp-quote dir)) file)))
+
 (provide 'mindstream-util)
 ;;; mindstream-util.el ends here

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -132,11 +132,43 @@ a file in FROM-DIR to refer to TO-DIR."
 	          (set-buffer-modified-p modflag))))
         (setq blist (cdr blist))))))
 
+(defun mindstream--close-buffers-at-path (path)
+  "Close all buffers in the PATH tree.
+
+If any buffers have been modified, they will be saved first."
+  (let ((blist (buffer-list)))
+    (while blist
+      (with-current-buffer (car blist)
+        (when (and buffer-file-name
+		           (mindstream--file-in-tree-p buffer-file-name
+                                               path))
+          (when (buffer-modified-p)
+            (save-buffer))
+          (kill-buffer)))
+      (setq blist (cdr blist)))))
+
 (defun mindstream--file-in-tree-p (file dir)
   "Is FILE part of the directory tree starting at DIR?"
   ;; Source: `dired-in-this-tree-p'
   (let (case-fold-search)
     (string-match-p (concat "^" (regexp-quote dir)) file)))
+
+(defun mindstream--session-name ()
+  "Name of the current session.
+
+This is simply the name of the containing folder."
+  ;; TODO: generalize to derive base repo path
+  ;; in case the file is in a nested path
+  (string-trim-left
+   (directory-file-name
+    (file-name-directory (buffer-file-name)))
+   "^.*/"))
+
+(defun mindstream--session-dir (file)
+  "The repo base path containing FILE."
+  ;; TODO: generalize to derive base repo path
+  ;; in case the file is in a nested path
+  (file-name-directory file))
 
 (provide 'mindstream-util)
 ;;; mindstream-util.el ends here

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -221,5 +221,26 @@ This is simply the name of the containing folder."
       ;; but magit-toplevel seems to work.
       (magit-toplevel))))
 
+(defun mindstream--get-containing-dir (file)
+  "Get the name of the directory containing FILE.
+
+FILE could be a file or a directory. Only the name of the containing
+directory is returned, rather than its full path."
+  (let ((file (if (directory-name-p file)
+                  (directory-file-name file)
+                file)))
+    (file-name-base
+     (directory-file-name
+      (file-name-directory
+       file)))))
+
+(defun mindstream--template-used (session)
+  "Name of the template used in the SESSION.
+
+SESSION is expected to be a full path to a session folder."
+  (let ((session  ; add trailing slash for good measure
+         (file-name-as-directory session)))
+    (mindstream--get-containing-dir session)))
+
 (provide 'mindstream-util)
 ;;; mindstream-util.el ends here

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -134,9 +134,8 @@ a file in FROM-DIR to refer to TO-DIR."
   (let* ((from-dir (file-name-as-directory
                     (expand-file-name
                      from-dir)))
-         (to-dir (file-name-as-directory
-                  (expand-file-name
-                   to-dir)))
+         (to-dir (expand-file-name
+                  to-dir))
          (from-pat from-dir)
          (to-pat (if (file-directory-p to-dir)
                      (concat to-dir
@@ -144,7 +143,11 @@ a file in FROM-DIR to refer to TO-DIR."
                               (mindstream--directory-name
                                from-dir)))
                    to-dir)))
-    (rename-file from-dir to-dir nil)
+    (rename-file from-dir
+                 (if (file-directory-p to-dir)
+                     (file-name-as-directory to-dir)
+                   to-dir)
+                 nil)
     ;; Update visited file name of all affected buffers
     (mindstream--for-all-buffers
      (lambda ()

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -96,36 +96,41 @@ platform-appropriate way.
 (defun mindstream--move-dir (from-dir to-dir)
   "Move folder FROM-DIR to TO-DIR.
 
+If TO-DIR already exists, then move FROM-DIR inside it, otherwise
+simply rename FROM-DIR to TO-DIR.
+
 This also updates the visited file names of all open buffers visiting
 a file in FROM-DIR to refer to TO-DIR."
   ;; Based on `dired-rename-file' and `dired-rename-subdir'
-  (rename-file from-dir to-dir nil)
-  (setq from-dir (file-name-as-directory from-dir)
-	    to-dir (file-name-as-directory to-dir))
-  ;; Update visited file name of all affected buffers
-  (let ((expanded-from-dir (expand-file-name from-dir))
-	    (blist (buffer-list)))
-    (while blist
-      (with-current-buffer (car blist)
-	    (if (and buffer-file-name
-		         (mindstream--file-in-tree-p buffer-file-name
-                                             expanded-from-dir))
-	        (let ((modflag (buffer-modified-p))
-                  ;; TODO: this is not a robust way to update
-                  ;; the visited file path, since
-                  ;; /a/b/a/c.txt -> /a/b/b/c.txt
-                  ;; would rewrite to /b/b/b/c.txt
-                  ;; but it works in "most" cases where
-                  ;; the renamed folder isn't a trailing
-                  ;; match on a containing folder name
-                  ;; Improve this.
-                  (to-file (replace-regexp-in-string
-			                (regexp-quote from-dir)
-			                to-dir
-			                buffer-file-name)))
-	          (set-visited-file-name to-file)
-	          (set-buffer-modified-p modflag))))
-      (setq blist (cdr blist)))))
+  (let* ((from-dir (file-name-as-directory
+                    (expand-file-name
+                     from-dir)))
+         (to-dir (file-name-as-directory
+                  (expand-file-name
+                   to-dir)))
+         (from-pat from-dir)
+         (to-pat (if (file-directory-p to-dir)
+                     (concat to-dir
+                             (file-name-as-directory
+                              (mindstream--directory-name
+                               from-dir)))
+                   to-dir)))
+    (rename-file from-dir to-dir nil)
+    ;; Update visited file name of all affected buffers
+    (let ((blist (buffer-list)))
+      (while blist
+        (with-current-buffer (car blist)
+	      (if (and buffer-file-name
+		           (mindstream--file-in-tree-p buffer-file-name
+                                               from-dir))
+	          (let ((modflag (buffer-modified-p))
+                    (to-file (replace-regexp-in-string
+                              (concat "^" (regexp-quote from-pat))
+			                  to-pat
+			                  buffer-file-name)))
+	            (set-visited-file-name to-file)
+	            (set-buffer-modified-p modflag))))
+        (setq blist (cdr blist))))))
 
 (defun mindstream--file-in-tree-p (file dir)
   "Is FILE part of the directory tree starting at DIR?"

--- a/mindstream.el
+++ b/mindstream.el
@@ -43,6 +43,7 @@
 
 (require 'mindstream-custom)
 (require 'mindstream-session)
+(require 'mindstream-backend)
 (require 'mindstream-util)
 
 (defvar mindstream-template-history nil
@@ -128,6 +129,29 @@ name, in a dedicated Git version-controlled folder at
   (let ((template (or template
                       (mindstream--completing-read-template))))
     (switch-to-buffer (mindstream--new template))))
+
+(defun mindstream-start-anonymous-session (&optional template)
+  "Start a new anonymous session.
+
+This creates a new directory and Git repository for the new session
+after copying over the contents of TEMPLATE if one is specified.
+Otherwise, it uses the configured default template.
+
+New sessions always start anonymous."
+  (let* ((template-path (mindstream--template-path template))
+         (filename (mindstream--starting-file-for-session template-path))
+         (path (mindstream--generate-anonymous-session-path template)))
+    (unless (file-directory-p path)
+      (copy-directory template-path path)
+      (mindstream-backend-initialize path)
+      (when mindstream-unique
+        (mindstream-archive-template-sessions template))
+      (find-file
+       (expand-file-name filename
+                         path))
+      (mindstream--initialize-buffer)
+      (mindstream-begin-session)
+      (current-buffer))))
 
 (defun mindstream-initialize ()
   "Do any setup that's necessary for Mindstream.

--- a/mindstream.el
+++ b/mindstream.el
@@ -348,5 +348,13 @@ taken if it is already a saved session."
       (mindstream--close-buffers-at-path dir)
       (mindstream--move-dir dir to-dir))))
 
+(defun mindstream-open (template)
+  "Open all active anonymous sessions for TEMPLATE."
+  (interactive (list
+                (mindstream--completing-read-template)))
+  (dolist (dir (mindstream--directory-dirs
+                (mindstream--anonymous-path template)))
+    (mindstream-load-session dir)))
+
 (provide 'mindstream)
 ;;; mindstream.el ends here

--- a/mindstream.el
+++ b/mindstream.el
@@ -326,40 +326,6 @@ features implementing the session iteration model."
       (mindstream--new (mindstream--template-path
                         (mindstream--infer-template major-mode)))))
 
-(defun mindstream--move-dir (from-dir to-dir)
-  "Move folder FROM-DIR to TO-DIR.
-
-This also updates the visited file names of all open buffers visiting
-a file in FROM-DIR to refer to TO-DIR."
-  ;; Based on `dired-rename-file' and `dired-rename-subdir'
-  (rename-file from-dir to-dir nil)
-  (setq from-dir (file-name-as-directory from-dir)
-	    to-dir (file-name-as-directory to-dir))
-  ;; Update visited file name of all affected buffers
-  (let ((expanded-from-dir (expand-file-name from-dir))
-	    (blist (buffer-list)))
-    (while blist
-      (with-current-buffer (car blist)
-	    (if (and buffer-file-name
-		         (mindstream--file-in-tree-p buffer-file-name
-                                             expanded-from-dir))
-	        (let ((modflag (buffer-modified-p))
-                  ;; TODO: this is not a robust way to update
-                  ;; the visited file path, since
-                  ;; /a/b/a/c.txt -> /a/b/b/c.txt
-                  ;; would rewrite to /b/b/b/c.txt
-                  ;; but it works in "most" cases where
-                  ;; the renamed folder isn't a trailing
-                  ;; match on a containing folder name
-                  ;; Improve this.
-                  (to-file (replace-regexp-in-string
-			                (regexp-quote from-dir)
-			                to-dir
-			                buffer-file-name)))
-	          (set-visited-file-name to-file)
-	          (set-buffer-modified-p modflag))))
-      (setq blist (cdr blist)))))
-
 (defun mindstream-enter-anonymous-session ()
   "Enter an anonymous session buffer.
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -146,6 +146,9 @@ can customize `mindstream-triggers' and add the function(s) that
 should trigger session iteration (and remove `save-buffer')."
   (mindstream--ensure-paths)
   (mindstream--ensure-templates-exist)
+  (unless mindstream-persist
+    ;; archive all sessions on startup
+    (mindstream-archive-all))
   (dolist (fn mindstream-triggers)
     (advice-add fn :around #'mindstream-implicitly-iterate-advice)))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -88,12 +88,15 @@ For example:
   (let ((template (car (last (split-string filename "/")))))
     (cons template filename)))
 
+(defun mindstream--list-templates ()
+  "List all templates by name."
+  (directory-files mindstream-template-path
+                   nil
+                   directory-files-no-dot-files-regexp))
+
 (defun mindstream--completing-read-template ()
   "Completion for template."
-  (let ((files (directory-files
-                mindstream-template-path
-                nil
-                directory-files-no-dot-files-regexp)))
+  (let ((files (mindstream--list-templates)))
     (completing-read "Which template? " files nil t nil
                      'mindstream-template-history)))
 
@@ -346,6 +349,11 @@ taken if it is already a saved session."
     (dolist (dir (mindstream--directory-dirs from-dir))
       (mindstream--close-buffers-at-path dir)
       (mindstream--move-dir dir to-dir))))
+
+(defun mindstream-archive ()
+  "Archive sessions for _all_ templates."
+  (dolist (template (mindstream--list-templates))
+    (mindstream-archive-template-sessions template)))
 
 (defun mindstream-open (template)
   "Open all active anonymous sessions for TEMPLATE."

--- a/mindstream.el
+++ b/mindstream.el
@@ -39,6 +39,7 @@
 ;;; Code:
 
 (require 'magit-git)
+(require 'dired)
 
 (require 'mindstream-custom)
 (require 'mindstream-session)
@@ -268,7 +269,11 @@ you would typically want to specify a new, non-existent folder."
     ;; note: this is a no-op if save-buffer is a trigger for iteration
     (mindstream--iterate)
     ;; TODO: verify behavior with existing vs non-existent containing folder
-    (copy-directory dir dest-dir)
+    (mindstream--move-dir dir dest-dir)
+    ;; TODO: this is a no-op, and it currently leaves the
+    ;; session in `mindsteam-active-sessions'. But that's OK
+    ;; for now as it doesn't affect anything, and this "state"
+    ;; will be removed eventually anyway in the design refactor
     (mindstream--end-anonymous-session)
     (if named
         (mindstream-load-session dest-dir file)
@@ -349,6 +354,39 @@ features implementing the session iteration model."
   (or (mindstream--get-anonymous-session-buffer)
       (mindstream--new (mindstream--template-path
                         (mindstream--infer-template major-mode)))))
+
+(defun mindstream--move-dir (from-dir to-dir)
+  "Move folder FROM-DIR to TO-DIR.
+
+This also updates the visited file names of all open buffers visiting
+a file in FROM-DIR to refer to TO-DIR."
+  ;; Based on `dired-rename-file' and `dired-rename-subdir'
+  (rename-file from-dir to-dir nil)
+  (setq from-dir (file-name-as-directory from-dir)
+	    to-dir (file-name-as-directory to-dir))
+  ;; Update visited file name of all affected buffers
+  (let ((expanded-from-dir (expand-file-name from-dir))
+	    (blist (buffer-list)))
+    (while blist
+      (with-current-buffer (car blist)
+	    (if (and buffer-file-name
+		         (dired-in-this-tree-p buffer-file-name expanded-from-dir))
+	        (let ((modflag (buffer-modified-p))
+                  ;; TODO: this is not a robust way to update
+                  ;; the visited file path, since
+                  ;; /a/b/a/c.txt -> /a/b/b/c.txt
+                  ;; would rewrite to /b/b/b/c.txt
+                  ;; but it works in "most" cases where
+                  ;; the renamed folder isn't a trailing
+                  ;; match on a containing folder name
+                  ;; Improve this.
+                  (to-file (replace-regexp-in-string
+			                (regexp-quote from-dir)
+			                to-dir
+			                buffer-file-name)))
+	          (set-visited-file-name to-file)
+	          (set-buffer-modified-p modflag))))
+      (setq blist (cdr blist)))))
 
 (defun mindstream-enter-anonymous-session ()
   "Enter an anonymous session buffer.

--- a/mindstream.el
+++ b/mindstream.el
@@ -142,10 +142,10 @@ New sessions always start anonymous."
          (filename (mindstream--starting-file-for-session template-path))
          (path (mindstream--generate-anonymous-session-path template)))
     (unless (file-directory-p path)
-      (copy-directory template-path path)
-      (mindstream-backend-initialize path)
       (when mindstream-unique
         (mindstream-archive-template-sessions template))
+      (copy-directory template-path path)
+      (mindstream-backend-initialize path)
       (find-file
        (expand-file-name filename
                          path))

--- a/mindstream.el
+++ b/mindstream.el
@@ -393,6 +393,7 @@ otherwise, it creates a new one and enters it."
                sessions))))
     (seq-uniq sessions)))
 
+;; TODO: archive should be ordered by recency, so that the current session is highlighted.
 (defun mindstream-archive (session)
   "Move the selected SESSION to `mindstream-archive-path'.
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -343,8 +343,7 @@ taken if it is already a saved session."
   (let ((from-dir (mindstream--anonymous-path template))
         (to-dir (mindstream--archive-path template)))
     (mindstream--ensure-path to-dir)
-    (dolist (dir (mindstream--directory-dirs from-dir
-                                             t))
+    (dolist (dir (mindstream--directory-dirs from-dir))
       (mindstream--close-buffers-at-path dir)
       (mindstream--move-dir dir to-dir))))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -347,7 +347,7 @@ want to get a session buffer for the current major mode, without
 worrying about how that happens. It is too connoted to be useful in
 features implementing the session iteration model."
   (or (mindstream--get-anonymous-session-buffer)
-      (mindstream--new (mindstream--template
+      (mindstream--new (mindstream--template-path
                         (mindstream--infer-template major-mode)))))
 
 (defun mindstream-enter-anonymous-session ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -375,10 +375,6 @@ archive saved sessions."
         (to-dir (mindstream--archive-path template)))
     (mindstream--ensure-path to-dir)
     (when sessions
-      ;; TODO: should we ensure that all template paths
-      ;; exist in the anon path at startup, even for
-      ;; templates where we haven't created any sessions
-      ;; yet?
       (dolist (dir sessions)
         (mindstream--close-buffers-at-path dir)
         (mindstream--move-dir dir to-dir)))))

--- a/mindstream.el
+++ b/mindstream.el
@@ -340,18 +340,11 @@ taken if it is already a saved session."
   "Archive all sessions associated with TEMPLATE."
   (interactive (list
                 (mindstream--completing-read-template)))
-  (let ((from-dir (mindstream--build-path mindstream-path
-                                          template))
-        (to-dir (mindstream--build-path mindstream-archive-path
-                                        template)))
-    (mindstream--ensure-path
-     (mindstream--build-path mindstream-archive-path
-                             template))
-    (dolist (dir (seq-filter (lambda (dir)
-                               (file-directory-p dir))
-                             (mindstream--directory-files
-                              from-dir
-                              t)))
+  (let ((from-dir (mindstream--anonymous-path template))
+        (to-dir (mindstream--archive-path template)))
+    (mindstream--ensure-path to-dir)
+    (dolist (dir (mindstream--directory-dirs from-dir
+                                             t))
       (mindstream--close-buffers-at-path dir)
       (mindstream--move-dir dir to-dir))))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -347,20 +347,18 @@ the file to be opened."
            buffer-file-name
            (mindstream--anonymous-path template))))))
 
-(defun mindstream--get-or-create-session ()
-  "Get the anonymous session buffer or create a new one.
+(defun mindstream--get-or-create-session (template)
+  "Get an existing anonymous session buffer for TEMPLATE or create a new one.
 
-If an anonymous buffer doesn't exist, this creates a new one using the
-default configured template.
+If an anonymous buffer doesn't exist, this creates a new one using TEMPLATE.
 
 This is a convenience utility for \"read only\" cases where we simply
 want to get a session buffer for the current major mode, without
 worrying about how that happens. It is too connoted to be useful in
 features implementing the session iteration model."
-  (let ((template (mindstream--infer-template major-mode)))
-    (or (mindstream--visit-anonymous-session template)
-        (mindstream-open template)
-        (mindstream--new template))))
+  (or (mindstream--visit-anonymous-session template)
+      (mindstream-open template)
+      (mindstream--new template)))
 
 (defun mindstream-enter-anonymous-session ()
   "Enter an anonymous session buffer.
@@ -368,7 +366,19 @@ features implementing the session iteration model."
 This enters an existing anonymous session if one is present,
 otherwise, it creates a new one and enters it."
   (interactive)
-  (let ((buf (mindstream--get-or-create-session)))
+  (let ((buf (mindstream--get-or-create-session
+              (mindstream--infer-template
+               major-mode))))
+    (switch-to-buffer buf)))
+
+(defun mindstream-enter-session-for-template (template)
+  "Enter an anonymous session buffer.
+
+This enters an existing anonymous session if one is present,
+otherwise, it creates a new one and enters it."
+  (interactive (list
+                (mindstream--completing-read-template)))
+  (let ((buf (mindstream--get-or-create-session template)))
     (switch-to-buffer buf)))
 
 (defun mindstream--list-anonymous-sessions ()

--- a/mindstream.el
+++ b/mindstream.el
@@ -239,7 +239,7 @@ you would typically want to specify a new, non-existent folder."
   ;; The chosen name of the directory becomes the name of the session.
   (let* ((original-session-name (mindstream--session-name))
          (file (file-name-nondirectory (buffer-file-name)))
-         (dir (mindstream--session-dir (buffer-file-name)))
+         (dir (mindstream--session-dir (current-buffer)))
          (named (not (file-directory-p dest-dir))))
     ;; ensure no unsaved changes
     ;; note: this is a no-op if save-buffer is a trigger for iteration

--- a/mindstream.el
+++ b/mindstream.el
@@ -65,11 +65,13 @@ can be retrieved and canceled when you leave live mode.")
   (let ((mindstream-map (make-sparse-keymap)))
     (define-key mindstream-map (kbd "C-c , n") #'mindstream-new)
     (define-key mindstream-map (kbd "C-c , b") #'mindstream-enter-anonymous-session)
+    (define-key mindstream-map (kbd "C-c , t") #'mindstream-enter-session-for-template)
     (define-key mindstream-map (kbd "C-c , m") #'mindstream-begin-session)
     (define-key mindstream-map (kbd "C-c , q") #'mindstream-end-session)
     (define-key mindstream-map (kbd "C-c , s") #'mindstream-save-session)
     (define-key mindstream-map (kbd "C-c , C-s") #'mindstream-save-session)
     (define-key mindstream-map (kbd "C-c , r") #'mindstream-load-session)
+    (define-key mindstream-map (kbd "C-c , a") #'mindstream-archive)
     (define-key mindstream-map (kbd "C-c , C-l") #'mindstream-go-live)
     (define-key mindstream-map (kbd "C-c , C-o") #'mindstream-go-offline)
 
@@ -392,7 +394,7 @@ otherwise, it creates a new one and enters it."
     (seq-uniq sessions)))
 
 (defun mindstream-archive (session)
-  "Move the current SESSION to `mindstream-archive-path'.
+  "Move the selected SESSION to `mindstream-archive-path'.
 
 The session is expected to be anonymous - it does not make sense to
 archive saved sessions."

--- a/mindstream.el
+++ b/mindstream.el
@@ -333,7 +333,7 @@ the file to be opened."
     (expand-file-name file mindstream-save-session-path)))
 
 (defun mindstream--list-template-sessions (template)
-  "List all active anonymous sessions for template."
+  "List all active anonymous sessions for TEMPLATE."
   (let ((path (mindstream--anonymous-path template)))
     (when (file-directory-p path)
       (mindstream--directory-dirs path))))
@@ -382,7 +382,7 @@ otherwise, it creates a new one and enters it."
     (seq-uniq sessions)))
 
 (defun mindstream-archive (session)
-  "Move the current session to `mindstream-archive-path'.
+  "Move the current SESSION to `mindstream-archive-path'.
 
 The session is expected to be anonymous - it does not make sense to
 archive saved sessions."

--- a/mindstream.el
+++ b/mindstream.el
@@ -346,9 +346,14 @@ taken if it is already a saved session."
   (let ((from-dir (mindstream--anonymous-path template))
         (to-dir (mindstream--archive-path template)))
     (mindstream--ensure-path to-dir)
-    (dolist (dir (mindstream--directory-dirs from-dir))
-      (mindstream--close-buffers-at-path dir)
-      (mindstream--move-dir dir to-dir))))
+    (when (file-directory-p from-dir)
+      ;; TODO: should we ensure that all template paths
+      ;; exist in the anon path at startup, even for
+      ;; templates where we haven't created any sessions
+      ;; yet?
+      (dolist (dir (mindstream--directory-dirs from-dir))
+        (mindstream--close-buffers-at-path dir)
+        (mindstream--move-dir dir to-dir)))))
 
 (defun mindstream-archive ()
   "Archive sessions for _all_ templates."


### PR DESCRIPTION
### Summary of Changes

This rewires the core functionality to support #26 , and also includes some groundwork for #24 .

At a high level, it introduces two custom variables:

- `mindstream-persist` (default false) to support sessions persisting across Emacs restarts
- `mindstream-unique` (default true) to support more than one concurrent anonymous session per template

These customizations are independent, and either or both could be enabled at the same time. In order to implement these features, we introduce a new concept of "archiving" anonymous sessions.

Formerly, anonymous sessions were stored in a flat folder structure at `mindstream-path`. Now, these sessions are indexed under subdirectories corresponding to the name of the template from which these sessions were spawned. This helps us keep track of them, but in addition, it also allows us to naturally support template-specific uniqueness and persistence.

_Any_ session at the anonymous path is now considered "active." Sessions that are no longer to be considered active are now archived, that is, moved to `mindstream-archive-path`. This is done implicitly by `mindstream-new` if `mindstream-unique` is true (the default), or it could also be done manually via `mindstream-archive`.

As a result, when Emacs starts up, if `mindstream-persist` is true, entering an anonymous session for a template will pull up all existing sessions at the template subdirectory in the anonymous path (i.e. satisfying #26 ). Likewise, if `mindstream-unique` is true, all existing anonymous sessions are archived at startup.

In other words, setting `mindstream-unique` to true and `mindstream-persist` to false (nil) reproduces the current behavior on the main branch. But we gain the ability to customize it along these two axes.

With the new addition, there are now four standard paths of interest with Mindstream. To streamline them, we place them all under `~/mindstream/` by default, except for the template path, which is retained in the `.emacs.d` folder by default so that it is portable along with the rest of our Emacs config. The template path is about _configuration_, whereas the other paths are about _content_. For context, these are the default paths:

- `~/.emacs.d/mindstream/templates`
- `~/mindstream/anon`
- `~/mindstream/archive`
- `~/mindstream/saved`

There are also a number of other changes:

- Saving an anonymous session _moves_ (i.e. renames) rather an copies the folder. This removes it from the anonymous path, preserving our expectations about sessions at the anonymous path being "active." It also ensures that if there are multiple buffers open in the project, they will all remain open after the move to the new location.
- Remove leftover code treating the starting buffer in a template as a "scratch" buffer. Since templates are full directories, and since sessions are full repositories, it doesn't make sense to consider any particular buffer a "scratch" buffer.
- In the general direction of #24 and #18, continue to reduce reliance on Emacs-specific state, and increasingly rely on filesystem state instead. Specifically, we no longer set a name for any buffers in the anonymous session, and do not use such a name (like `*Scratch - Org*`) in any logic. Instead we infer that sessions are anonymous based only on their filesystem path, as suggested in #26. Additionally, all anonymous session interaction occurs through (filesystem-based) _templates_ as the intermediary, even for "major mode" anonymous sessions (which infer a template first to hook into the template-based logic).
- Add some useful utility functions for core concepts and filesystem interaction.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
