### PR TITLE
Date-based Filing

### DIFF
--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -177,13 +177,17 @@ default template."
                           (or template mindstream-default-template)))
 
 (defun mindstream--archive-path (&optional template)
-  "Path to archived sessions using TEMPLATE.
+  "Path where sessions using TEMPLATE should be archived.
+
+The path includes the current date so that anonymous sessions when
+archived are easier to find and more useful as a log.
 
 TEMPLATE is expected to be a simple name corresponding to the name of
 a folder at `mindstream-template-path'.  If it isn't provided, use the
 default template."
   (mindstream--build-path mindstream-archive-path
-                          (or template mindstream-default-template)))
+                          (or template mindstream-default-template)
+                          (format-time-string "%Y-%m-%d")))
 
 (defun mindstream--template-name (path)
   "Name of template at PATH."

--- a/mindstream-session.el
+++ b/mindstream-session.el
@@ -55,10 +55,8 @@ number of active sessions is likely to be small.")
 
 (defun mindstream--unique-name ()
   "Generate a unique name."
-  (let ((time (current-time)))
-    (concat (format-time-string "%F" time)
-            "-"
-            (sha1 (format "%s" time)))))
+  (sha1
+   (format "%s" (current-time))))
 
 (defun mindstream--session-file-name-relative (file dir)
   "Return relative FILE name for `mindstream-session-history'.
@@ -153,7 +151,10 @@ That is, either the anonymous session path or the archive path."
 This creates an appropriate base path on disk for the TEMPLATE if it
 isn't already present."
   (let* ((session-name (mindstream--unique-name))
-         (base-path (mindstream--anonymous-path template)))
+         (filed-date (format-time-string "%F"))
+         (base-path (mindstream--build-path
+                     (mindstream--anonymous-path template)
+                     filed-date)))
     (mindstream--ensure-path base-path)
     (mindstream--build-path base-path
                             session-name)))
@@ -186,8 +187,7 @@ TEMPLATE is expected to be a simple name corresponding to the name of
 a folder at `mindstream-template-path'.  If it isn't provided, use the
 default template."
   (mindstream--build-path mindstream-archive-path
-                          (or template mindstream-default-template)
-                          (format-time-string "%Y-%m-%d")))
+                          (or template mindstream-default-template)))
 
 (defun mindstream--template-name (path)
   "Name of template at PATH."

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -216,7 +216,7 @@ This is simply the name of the containing folder."
 (defun mindstream--get-containing-dir (file &optional full)
   "Get the name of the directory containing FILE.
 
-FILE could be a file or a directory. If FULL is nil, only the name of
+FILE could be a file or a directory.  If FULL is nil, only the name of
 the containing directory is returned, rather than its full path,
 otherwise the full (absolute) path is returned."
   (let ((file (if (directory-name-p file)

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -206,26 +206,35 @@ This is simply the name of the containing folder."
   "The repo base path containing BUFFER."
   (mindstream-backend-root buffer))
 
-(defun mindstream--get-containing-dir (file)
+(defun mindstream--get-containing-dir (file &optional full)
   "Get the name of the directory containing FILE.
 
-FILE could be a file or a directory.  Only the name of the containing
-directory is returned, rather than its full path."
+FILE could be a file or a directory. If FULL is nil, only the name of
+the containing directory is returned, rather than its full path,
+otherwise the full (absolute) path is returned."
   (let ((file (if (directory-name-p file)
                   (directory-file-name file)
                 file)))
-    (file-name-base
-     (directory-file-name
-      (file-name-directory
-       file)))))
+    (let ((result (directory-file-name
+                   (file-name-directory
+                    file))))
+      (if full
+          result
+        (file-name-base result)))))
 
 (defun mindstream--template-used (session)
   "Name of the template used in the SESSION.
 
-SESSION is expected to be a full path to a session folder."
+SESSION is expected to be a full path to a session folder.
+
+This can only be used in paths managed by Mindstream, that is,
+anonymous and archive paths."
   (let ((session  ; add trailing slash for good measure
          (file-name-as-directory session)))
-    (mindstream--get-containing-dir session)))
+    ;; sessions are filed under template-name/date/session
+    (mindstream--get-containing-dir
+     (mindstream--get-containing-dir session
+                                     t))))
 
 (provide 'mindstream-util)
 ;;; mindstream-util.el ends here

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -191,6 +191,13 @@ If any buffers have been modified, they will be saved first."
         (dir (expand-file-name dir)))
     (string-match-p (concat "^" (regexp-quote dir)) path)))
 
+;; from Emacs source code in org-compat.el
+;; this is available natively in Emacs 28+
+(defun mindstream--directory-empty-p (dir)
+  "Is DIR empty?"
+  (and (file-directory-p dir)
+       (null (directory-files dir nil directory-files-no-dot-files-regexp t))))
+
 (defun mindstream--session-name ()
   "Name of the current session.
 

--- a/mindstream-util.el
+++ b/mindstream-util.el
@@ -76,7 +76,9 @@ Return FULL, absolute paths, or relative paths."
       files)))
 
 (defun mindstream--directory-dirs (dir)
-  "List subdirectories in DIR."
+  "List subdirectories in DIR.
+
+This returns absolute paths to the subdirectories."
   (seq-filter (lambda (file)
                 (file-directory-p file))
               (mindstream--directory-files dir

--- a/mindstream.el
+++ b/mindstream.el
@@ -172,7 +172,9 @@ can customize `mindstream-triggers' and add the function(s) that
 should trigger session iteration (and remove `basic-save-buffer')."
   (mindstream--ensure-paths)
   (mindstream--ensure-templates-exist)
-  (unless mindstream-persist
+  (if mindstream-persist
+      ;; open all existing anonymous sessions
+      (mindstream-open-all)
     ;; archive all sessions on startup
     (mindstream-archive-all))
   (dolist (fn mindstream-triggers)
@@ -335,7 +337,10 @@ the file to be opened."
     (expand-file-name file mindstream-save-session-path)))
 
 (defun mindstream--list-template-sessions (template)
-  "List all active anonymous sessions for TEMPLATE."
+  "List all active anonymous sessions for TEMPLATE.
+
+TEMPLATE is expected to be a name rather than a path. The sessions are
+returned as absolute paths to the session directories."
   (let ((path (mindstream--anonymous-path template)))
     (when (file-directory-p path)
       (mindstream--directory-dirs path))))
@@ -411,7 +416,9 @@ archive saved sessions."
                          (mindstream--archive-path template))))
 
 (defun mindstream-archive-template-sessions (template)
-  "Archive all sessions associated with TEMPLATE."
+  "Archive all sessions associated with TEMPLATE.
+
+TEMPLATE is expected to be a simple name rather than a full path."
   (interactive (list
                 (mindstream--completing-read-template)))
   (let ((sessions (mindstream--list-template-sessions template))
@@ -437,6 +444,29 @@ archive saved sessions."
       ;; TODO: seems artificial to return this just so we
       ;; have a no-op buffer to switch to in "enter session"
       (current-buffer))))
+
+(defun mindstream-open-all ()
+  "Open anonymous sessions for _all_ templates."
+  (dolist (template (mindstream--list-templates))
+    (mindstream-open template)))
+
+(defun mindstream-close-session (dir)
+  "Close all open buffers at DIR."
+  (mindstream--close-buffers-at-path dir))
+
+(defun mindstream-close (template)
+  "Close all open sessions for TEMPLATE."
+  (interactive (list
+                (mindstream--completing-read-template)))
+  (let ((sessions (mindstream--list-template-sessions template)))
+    (dolist (dir sessions)
+      (mindstream-close-session dir))))
+
+(defun mindstream-close-all ()
+  "Close anonymous sessions for _all_ templates."
+  (interactive)
+  (dolist (template (mindstream--list-templates))
+    (mindstream-close template)))
 
 (provide 'mindstream)
 ;;; mindstream.el ends here

--- a/mindstream.el
+++ b/mindstream.el
@@ -160,8 +160,8 @@ New sessions always start anonymous."
   "Do any setup that's necessary for Mindstream.
 
 This advises any functions that should implicitly cause the session to
-iterate. By default, this is just `basic-save-buffer', so that the
-session is iterated every time the buffer is saved. This is the
+iterate.  By default, this is just `basic-save-buffer', so that the
+session is iterated every time the buffer is saved.  This is the
 recommended usage, intended to capture \"natural\" points at which the
 session is meaningful.
 
@@ -338,7 +338,7 @@ the file to be opened."
 (defun mindstream--list-template-sessions (template)
   "List all active anonymous sessions for TEMPLATE.
 
-TEMPLATE is expected to be a name rather than a path. The sessions are
+TEMPLATE is expected to be a name rather than a path.  The sessions are
 returned as absolute paths to the session directories."
   (let ((path (mindstream--anonymous-path template)))
     (when (file-directory-p path)
@@ -372,19 +372,8 @@ features implementing the session iteration model."
       (mindstream-open template)
       (mindstream--new template)))
 
-(defun mindstream-enter-anonymous-session ()
-  "Enter an anonymous session buffer.
-
-This enters an existing anonymous session if one is present,
-otherwise, it creates a new one and enters it."
-  (interactive)
-  (let ((buf (mindstream--get-or-create-session
-              (mindstream--infer-template
-               major-mode))))
-    (switch-to-buffer buf)))
-
 (defun mindstream-enter-session-for-template (template)
-  "Enter an anonymous session buffer.
+  "Enter an anonymous session buffer for TEMPLATE.
 
 This enters an existing anonymous session if one is present,
 otherwise, it creates a new one and enters it."
@@ -392,6 +381,17 @@ otherwise, it creates a new one and enters it."
                 (mindstream--completing-read-template)))
   (let ((buf (mindstream--get-or-create-session template)))
     (switch-to-buffer buf)))
+
+(defun mindstream-enter-anonymous-session ()
+  "Enter a relevant anonymous session buffer.
+
+This infers the template based on the current major mode and then
+enters an existing anonymous session for that template if one is
+present, otherwise, it creates a new one and enters it."
+  (interactive)
+  (mindstream-enter-session-for-template
+   (mindstream--infer-template
+    major-mode)))
 
 (defun mindstream--list-anonymous-sessions ()
   "List anonymous session paths."
@@ -408,7 +408,7 @@ otherwise, it creates a new one and enters it."
   (mindstream--close-buffers-at-path dir))
 
 (defun mindstream--archive (session-dir template)
-  "Close all open buffers at SESSION-DIR and move it to the archive."
+  "Close all open buffers at SESSION-DIR and move it to the archive for TEMPLATE."
   ;; first close the session
   (mindstream-close-session session-dir)
   ;; then move it to its new location in the archive

--- a/mindstream.el
+++ b/mindstream.el
@@ -430,6 +430,7 @@ TEMPLATE is expected to be a simple name rather than a full path."
 
 (defun mindstream-archive-all ()
   "Archive sessions for _all_ templates."
+  (interactive)
   (dolist (template (mindstream--list-templates))
     (mindstream-archive-template-sessions template)))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -464,6 +464,7 @@ TEMPLATE is expected to be a simple name rather than a full path."
 
 (defun mindstream-open-all ()
   "Open anonymous sessions for _all_ templates."
+  (interactive)
   (dolist (template (mindstream--list-templates))
     (mindstream-open template)))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -343,7 +343,13 @@ TEMPLATE is expected to be a name rather than a path. The sessions are
 returned as absolute paths to the session directories."
   (let ((path (mindstream--anonymous-path template)))
     (when (file-directory-p path)
-      (mindstream--directory-dirs path))))
+      (let ((date-dirs (mindstream--directory-dirs path))
+            (result nil))
+        (dolist (dir date-dirs)
+          (setq result
+                (append result
+                        (mindstream--directory-dirs dir))))
+        result))))
 
 (defun mindstream--visit-anonymous-session (template)
   "Visit the most recent open anonymous session for TEMPLATE."
@@ -404,9 +410,14 @@ otherwise, it creates a new one and enters it."
 
 (defun mindstream--archive (session-dir template)
   "Close all open buffers at SESSION-DIR and move it to the archive."
-  (let ((to-dir (mindstream--archive-path template)))
+  ;; first close the session
+  (mindstream-close-session session-dir)
+  ;; then move it to its new location in the archive
+  (let* ((base-path (mindstream--archive-path template))
+         (date-dir (mindstream--get-containing-dir session-dir))
+         (to-dir (mindstream--build-path base-path
+                                         date-dir)))
     (mindstream--ensure-path to-dir)
-    (mindstream-close-session session-dir)
     (mindstream--move-dir session-dir
                           to-dir)))
 

--- a/mindstream.el
+++ b/mindstream.el
@@ -398,10 +398,17 @@ otherwise, it creates a new one and enters it."
                sessions))))
     (seq-uniq sessions)))
 
-(defun mindstream--archive (dir to-dir)
-  "Close all open buffers at DIR and move DIR to TO-DIR."
-  (mindstream--close-buffers-at-path dir)
-  (mindstream--move-dir dir to-dir))
+(defun mindstream-close-session (dir)
+  "Close all open buffers at DIR."
+  (mindstream--close-buffers-at-path dir))
+
+(defun mindstream--archive (session-dir template)
+  "Close all open buffers at SESSION-DIR and move it to the archive."
+  (let ((to-dir (mindstream--archive-path template)))
+    (mindstream--ensure-path to-dir)
+    (mindstream-close-session session-dir)
+    (mindstream--move-dir session-dir
+                          to-dir)))
 
 ;; TODO: archive should be ordered by recency, so that the current session is highlighted.
 (defun mindstream-archive (session)
@@ -413,7 +420,7 @@ archive saved sessions."
                                       (mindstream--list-anonymous-sessions))))
   (let ((template (mindstream--template-used session)))
     (mindstream--archive session
-                         (mindstream--archive-path template))))
+                         template)))
 
 (defun mindstream-archive-template-sessions (template)
   "Archive all sessions associated with TEMPLATE.
@@ -421,12 +428,11 @@ archive saved sessions."
 TEMPLATE is expected to be a simple name rather than a full path."
   (interactive (list
                 (mindstream--completing-read-template)))
-  (let ((sessions (mindstream--list-template-sessions template))
-        (to-dir (mindstream--archive-path template)))
-    (mindstream--ensure-path to-dir)
+  (let ((sessions (mindstream--list-template-sessions template)))
     (when sessions
       (dolist (dir sessions)
-        (mindstream--archive dir to-dir)))))
+        (mindstream--archive dir
+                             template)))))
 
 (defun mindstream-archive-all ()
   "Archive sessions for _all_ templates."
@@ -450,10 +456,6 @@ TEMPLATE is expected to be a simple name rather than a full path."
   "Open anonymous sessions for _all_ templates."
   (dolist (template (mindstream--list-templates))
     (mindstream-open template)))
-
-(defun mindstream-close-session (dir)
-  "Close all open buffers at DIR."
-  (mindstream--close-buffers-at-path dir))
 
 (defun mindstream-close (template)
   "Close all open sessions for TEMPLATE."

--- a/mindstream.el
+++ b/mindstream.el
@@ -414,11 +414,14 @@ otherwise, it creates a new one and enters it."
   ;; then move it to its new location in the archive
   (let* ((base-path (mindstream--archive-path template))
          (date-dir (mindstream--get-containing-dir session-dir))
+         (anon-date-dir (mindstream--get-containing-dir session-dir t))
          (to-dir (mindstream--build-path base-path
                                          date-dir)))
     (mindstream--ensure-path to-dir)
     (mindstream--move-dir session-dir
-                          to-dir)))
+                          to-dir)
+    (when (mindstream--directory-empty-p anon-date-dir)
+      (delete-directory anon-date-dir))))
 
 ;; TODO: archive should be ordered by recency, so that the current session is highlighted.
 (defun mindstream-archive (session)

--- a/mindstream.el
+++ b/mindstream.el
@@ -393,6 +393,11 @@ otherwise, it creates a new one and enters it."
                sessions))))
     (seq-uniq sessions)))
 
+(defun mindstream--archive (dir to-dir)
+  "Close all open buffers at DIR and move DIR to TO-DIR."
+  (mindstream--close-buffers-at-path dir)
+  (mindstream--move-dir dir to-dir))
+
 ;; TODO: archive should be ordered by recency, so that the current session is highlighted.
 (defun mindstream-archive (session)
   "Move the selected SESSION to `mindstream-archive-path'.
@@ -402,10 +407,8 @@ archive saved sessions."
   (interactive (list (completing-read "Which session? "
                                       (mindstream--list-anonymous-sessions))))
   (let ((template (mindstream--template-used session)))
-    (mindstream--close-buffers-at-path session)
-    (mindstream--move-dir session
-                          (mindstream--build-path mindstream-archive-path
-                                                  template))))
+    (mindstream--archive session
+                         (mindstream--archive-path template))))
 
 (defun mindstream-archive-template-sessions (template)
   "Archive all sessions associated with TEMPLATE."
@@ -416,8 +419,7 @@ archive saved sessions."
     (mindstream--ensure-path to-dir)
     (when sessions
       (dolist (dir sessions)
-        (mindstream--close-buffers-at-path dir)
-        (mindstream--move-dir dir to-dir)))))
+        (mindstream--archive dir to-dir)))))
 
 (defun mindstream-archive-all ()
   "Archive sessions for _all_ templates."

--- a/mindstream.el
+++ b/mindstream.el
@@ -72,6 +72,7 @@ can be retrieved and canceled when you leave live mode.")
     (define-key mindstream-map (kbd "C-c , C-s") #'mindstream-save-session)
     (define-key mindstream-map (kbd "C-c , r") #'mindstream-load-session)
     (define-key mindstream-map (kbd "C-c , a") #'mindstream-archive)
+    (define-key mindstream-map (kbd "C-c , o") #'mindstream-open)
     (define-key mindstream-map (kbd "C-c , C-l") #'mindstream-go-live)
     (define-key mindstream-map (kbd "C-c , C-o") #'mindstream-go-offline)
 
@@ -172,9 +173,7 @@ can customize `mindstream-triggers' and add the function(s) that
 should trigger session iteration (and remove `basic-save-buffer')."
   (mindstream--ensure-paths)
   (mindstream--ensure-templates-exist)
-  (if mindstream-persist
-      ;; open all existing anonymous sessions
-      (mindstream-open-all)
+  (unless mindstream-persist
     ;; archive all sessions on startup
     (mindstream-archive-all))
   (dolist (fn mindstream-triggers)


### PR DESCRIPTION
### Summary of Changes

We now file sessions in both the anonymous path and in the archive by their date of creation.

This should make the archive much more useful as an indexed log of what we were working on over time.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
